### PR TITLE
result: options compatibility

### DIFF
--- a/stew/results.nim
+++ b/stew/results.nim
@@ -573,3 +573,32 @@ template `?`*[T, E](self: Result[T, E]): T =
   if v.isErr: return err(typeof(result), v.error)
 
   v.value
+
+# Options compatibility
+
+import options
+export options
+
+when defined(resultsExperimental):
+  {.pragma: resexp.}
+else:
+  {.pragma: resexp, deprecated: "experimental".}
+
+func ok*[T, E](r: Result[T, E]): Option[T] {.resexp.} =
+  if r.isOk():
+    return some(r.v)
+
+func err*[T, E](r: Result[T, E]): Option[E] {.resexp.} =
+  if r.isErr():
+    return some(r.e)
+
+func mapErr*[T, E](o: Option[T], f: proc (): E): Result[T, E] {.resexp.} =
+  if o.isSome():
+    ok(o.get())
+  else:
+    err(f())
+
+# Options extras
+
+func contains*[T](o: Option[T], v: T): bool {.resexp.} =
+  o.isSome() and o.get() == v

--- a/tests/test_results.nim
+++ b/tests/test_results.nim
@@ -240,3 +240,18 @@ except:
   discard
 
 doAssert vErr.mapErr(proc(x: int): int = 10).error() == 10
+
+doAssert rOk.ok().get() == rOk.get()
+doAssert rOk.err().isNone()
+doAssert rErr.ok().isNone()
+doAssert rErr.err().get() == rErr.error()
+
+let
+  oSome = some(100)
+  oNone = none(int)
+
+doAssert oSome.mapErr(proc(): int = 200).get() == oSome.get()
+doAssert oNone.mapErr(proc(): int = 200).error() == 200
+
+doAssert rOk.get() in rOk.ok() # "contains"
+doAssert rErr.error() in rErr.err()


### PR DESCRIPTION
motivating example for `contains`:

```
if IndexError in res.err():  # calls error-to-option then `contains`
  ...
```
