### PR TITLE
deprecate ranges

### DIFF
--- a/stew/ranges.nim
+++ b/stew/ranges.nim
@@ -1,3 +1,5 @@
+{.deprecated: "unattractive memory unsafety - use openArray and other techniques instead".}
+
 import
   ranges/memranges,
   ranges/typedranges

--- a/stew/ranges/memranges.nim
+++ b/stew/ranges/memranges.nim
@@ -1,3 +1,5 @@
+{.deprecated: "unattractive memory unsafety - use openArray and other techniques instead".}
+
 import
   ptr_arith
 

--- a/stew/ranges/typedranges.nim
+++ b/stew/ranges/typedranges.nim
@@ -1,3 +1,5 @@
+{.deprecated: "unattractive memory unsafety - use openArray and other techniques instead".}
+
 import ../ptrops, typetraits, hashes
 
 const rangesGCHoldEnabled = not defined(rangesDisableGCHold)


### PR DESCRIPTION
Without lifetime tracking, ranges pose a number of issues with regards
to memory safety - use openArray instead which is limited but safe.

In its present form, ranges take a copy of whatever is passed to them
which obscures the copies that they take, leading to misleading and slow
code.

If openArray is not applicable, simply do a seq copy - it's fine and
really doesn't matter in 95% of all cases, then profile and use other
techniques where needed.