### PR TITLE
Fix #47

### DIFF
--- a/stew/ptrops.nim
+++ b/stew/ptrops.nim
@@ -36,8 +36,9 @@ template offset*[T](p: ptr T, count: int): ptr T =
   # better optimizations.
 
   # We turn off checking here - too large counts is UB
-  {.checks: off.}
+  {.push checks: off.}
   let bytes = count * sizeof(T)
+  {.pop.}
   cast[ptr T](offset(cast[pointer](p), bytes))
 
 template distance*(a, b: pointer): int =
@@ -50,5 +51,5 @@ template distance*(a, b: pointer): int =
 template distance*[T](a, b: ptr T): int =
   # Number of elements between a and b - undefined behavior when difference
   # exceeds what can be represented in an int
-  {.checks: off.}
   distance(cast[pointer](a), cast[pointer](b)) div sizeof(T)
+


### PR DESCRIPTION
As far as I can tell, this preserves the intended lack of checks in these low-level routines while dealing with the problem explained in #47. By default, Nim insert checks only for `int` operands. The `uint` arithmetic used in `offset` and `distance` doesn't introduce any checks.

