### PR TITLE
fix use of compiler intrinsics in endians/bitops

### DIFF
--- a/stew.nimble
+++ b/stew.nimble
@@ -12,6 +12,7 @@ requires "nim >= 1.2.0"
 task test, "Run all tests":
   exec "nim c -r --threads:off tests/all_tests"
   exec "nim c -r --threads:on -d:nimTypeNames tests/all_tests"
+  exec "nim c -r --threads:on -d:noIntrinsicsBitOpts -d:noIntrinsicsEndians tests/all_tests"
 
 task testvcc, "Run all tests with vcc compiler":
   exec "nim c -r --cc:vcc --threads:off tests/all_tests"

--- a/stew/endians2.nim
+++ b/stew/endians2.nim
@@ -28,7 +28,10 @@ type
     ## * intX - over and underflow protection in nim might easily cause issues -
     ##          need to consider before adding here
 
-when defined(gcc) or defined(llvm_gcc) or defined(clang):
+const
+  useBuiltins = not defined(noIntrinsicsEndians)
+
+when (defined(gcc) or defined(llvm_gcc) or defined(clang)) and useBuiltins:
   func swapBytesBuiltin(x: uint8): uint8 = x
   func swapBytesBuiltin(x: uint16): uint16 {.
       importc: "__builtin_bswap16", nodecl.}
@@ -39,13 +42,13 @@ when defined(gcc) or defined(llvm_gcc) or defined(clang):
   func swapBytesBuiltin(x: uint64): uint64 {.
       importc: "__builtin_bswap64", nodecl.}
 
-elif defined(icc):
+elif defined(icc) and useBuiltins:
   func swapBytesBuiltin(x: uint8): uint8 = x
   func swapBytesBuiltin(a: uint16): uint16 {.importc: "_bswap16", nodecl.}
   func swapBytesBuiltin(a: uint32): uint32 {.importc: "_bswap", nodec.}
   func swapBytesBuiltin(a: uint64): uint64 {.importc: "_bswap64", nodecl.}
 
-elif defined(vcc):
+elif defined(vcc) and useBuiltins:
   func swapBytesBuiltin(x: uint8): uint8 = x
   func swapBytesBuiltin(a: uint16): uint16 {.
       importc: "_byteswap_ushort", cdecl, header: "<intrin.h>".}
@@ -82,7 +85,7 @@ func swapBytes*[T: SomeEndianInt](x: T): T {.inline.} =
   when nimvm:
     swapBytesNim(x)
   else:
-    when defined(swapBytesBuiltin):
+    when declared(swapBytesBuiltin):
       swapBytesBuiltin(x)
     else:
       swapBytesNim(x)


### PR DESCRIPTION
I was wondering why I saw native nim versions in performance traces...