### PR TITLE
Console input/output procedures.

### DIFF
--- a/stew/conio.nim
+++ b/stew/conio.nim
@@ -305,8 +305,9 @@ elif defined(posix):
         let res = read(STDIN_FILENO, cast[pointer](addr buffer[0]),
                        len(buffer))
         if res < 0:
+          let errCode = ioLastError()
           discard tcSetAttr(STDIN_FILENO, TCSADRAIN, addr(old))
-          return err(ioLastError())
+          return err(errCode)
 
         if tcSetAttr(STDIN_FILENO, TCSADRAIN, addr(old)) != cint(0):
           return err(ioLastError())

--- a/stew/conio.nim
+++ b/stew/conio.nim
@@ -355,7 +355,7 @@ elif defined(posix):
         if maxChars < len(wbuffer):
           wbuffer.setLen(maxChars)
         # Conversion of wide characters sequence to UTF-8 encoded string.
-        let ures = wbuffer.wcharToUtf8()
+        let ures = wbuffer.utf32toUtf8()
         if ures.isOk():
           ok(ures.get())
         else:

--- a/stew/conio.nim
+++ b/stew/conio.nim
@@ -260,12 +260,9 @@ elif defined(posix):
   proc isConsoleRedirected(consoleFd: cint): bool =
     ## Returns ``true`` if console handle was redirected.
     var mode: Termios
+    # This is how `isatty()` checks for TTY.
     if tcGetAttr(consoleFd, addr mode) != cint(0):
-      let errCode = ioLastError()
-      if errCode == ENOTTY:
-        true
-      else:
-        false
+      true
     else:
       false
 

--- a/stew/conio.nim
+++ b/stew/conio.nim
@@ -63,7 +63,7 @@ when defined(windows):
     ENABLE_ECHO_INPUT = 0x0004'u32
     FILE_TYPE_CHAR = 0x0002'u32
 
-  proc isConsoleRedirected(hConsole: uint): bool =
+  proc isConsoleRedirected*(hConsole: uint): bool =
     ## Returns ``true`` if console handle was redirected.
     let res = getFileType(hConsole)
     if res == FILE_TYPE_CHAR:
@@ -257,7 +257,7 @@ when defined(windows):
 elif defined(posix):
   import posix, termios
 
-  proc isConsoleRedirected(consoleFd: cint): bool =
+  proc isConsoleRedirected*(consoleFd: cint): bool =
     ## Returns ``true`` if console handle was redirected.
     var mode: Termios
     # This is how `isatty()` checks for TTY.

--- a/stew/conio.nim
+++ b/stew/conio.nim
@@ -1,0 +1,340 @@
+## Copyright (c) 2020 Status Research & Development GmbH
+## Licensed under either of
+##  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE))
+##  * MIT license ([LICENSE-MIT](LICENSE-MIT))
+## at your option.
+## This file may not be copied, modified, or distributed except according to
+## those terms.
+
+## This module implements cross-platform console procedures.
+import io2
+export io2
+
+when defined(windows):
+  proc setConsoleOutputCP(wCodePageID: cuint): int32 {.
+       importc: "SetConsoleOutputCP", stdcall, dynlib: "kernel32", sideEffect.}
+  proc setConsoleCP(wCodePageID: cuint): int32 {.
+       importc: "SetConsoleCP", stdcall, dynlib: "kernel32", sideEffect.}
+  proc getConsoleCP(): cuint {.
+       importc: "GetConsoleCP", stdcall, dynlib: "kernel32", sideEffect.}
+  proc getConsoleOutputCP(): cuint {.
+       importc: "GetConsoleOutputCP", stdcall, dynlib: "kernel32", sideEffect.}
+  proc setConsoleMode(hConsoleHandle: uint, dwMode: uint32): int32 {.
+       importc: "SetConsoleMode", stdcall, dynlib: "kernel32", sideEffect.}
+  proc getConsoleMode(hConsoleHandle: uint, dwMode: var uint32): int32 {.
+       importc: "GetConsoleMode", stdcall, dynlib: "kernel32", sideEffect.}
+  proc readConsole(hConsoleInput: uint, lpBuffer: pointer,
+                   nNumberOfCharsToRead: uint32,
+                   lpNumberOfCharsRead: var uint32,
+                   pInputControl: pointer): int32 {.
+       importc: "ReadConsoleW", stdcall, dynlib: "kernel32", sideEffect.}
+  proc readFile(hFile: uint, lpBuffer: pointer,
+                nNumberOfBytesToRead: uint32,
+                lpNumberOfBytesRead: var uint32,
+                lpOverlapped: pointer): int32 {.
+       importc: "ReadFile", dynlib: "kernel32", stdcall, sideEffect.}
+  proc writeConsole(hConsoleOutput: uint, lpBuffer: pointer,
+                    nNumberOfCharsToWrite: uint32,
+                    lpNumberOfCharsWritten: var uint32,
+                    lpReserved: pointer): int32 {.
+       importc: "WriteConsoleW", stdcall, dynlib: "kernel32", sideEffect.}
+  proc writeFile(hFile: uint, lpBuffer: pointer,
+                 nNumberOfBytesToWrite: uint32,
+                 lpNumberOfBytesWritten: var uint32,
+                 lpOverlapped: pointer): int32 {.
+       importc: "WriteFile", dynlib: "kernel32", stdcall, sideEffect.}
+  proc getStdHandle(nStdHandle: uint32): uint {.
+       importc: "GetStdHandle", stdcall, dynlib: "kernel32", sideEffect.}
+  proc wideCharToMultiByte(codePage: cuint, dwFlags: uint32,
+                           lpWideCharStr: ptr Utf16Char, cchWideChar: cint,
+                           lpMultiByteStr: ptr char, cbMultiByte: cint,
+                           lpDefaultChar: pointer,
+                           lpUsedDefaultChar: pointer): cint {.
+       importc: "WideCharToMultiByte", stdcall, dynlib: "kernel32", sideEffect.}
+
+  const
+    CP_UTF8 = 65001'u32
+    STD_INPUT_HANDLE = cast[uint32](-10)
+    STD_OUTPUT_HANDLE = cast[uint32](-11)
+    INVALID_HANDLE_VALUE = cast[uint](-1)
+    ENABLE_PROCESSED_INPUT = 0x0001'u32
+    ENABLE_ECHO_INPUT = 0x0004'u32
+    ERROR_INVALID_HANDLE = 0x0006'u32
+
+  proc isConsoleRedirected(hConsole: uint): bool =
+    ## Returns ``true`` if console handle was redirected.
+    var mode: uint32
+    let res = getConsoleMode(hConsole, mode)
+    if res == 0:
+      let errCode = ioLastError()
+      if errCode == ERROR_INVALID_HANDLE:
+        true
+      else:
+        false
+    else:
+      false
+
+  proc readConsoleInput(maxBytes: int): IoResult[string] =
+    let hConsoleInput =
+      block:
+        let res = getStdHandle(STD_INPUT_HANDLE)
+        if res == INVALID_HANDLE_VALUE:
+          return err(ioLastError())
+        res
+
+    let prevInputCP =
+      block:
+        let res = getConsoleCP()
+        if res == cuint(0):
+          return err(ioLastError())
+        res
+
+    if isConsoleRedirected(hConsoleInput):
+      # Console STDIN is redirected, we should use ReadFile(), because
+      # ReadConsole() is not working for such types of STDIN.
+      if setConsoleCP(CP_UTF8) == 0'i32:
+        return err(ioLastError())
+
+      # Allocating buffer with size equal to `maxBytes` + len(CRLF)
+      var buffer = newString(maxBytes + 2)
+      let bytesToRead = uint32(len(buffer))
+      var bytesRead: uint32
+      let rres = readFile(hConsoleInput, cast[pointer](addr buffer[0]),
+                          bytesToRead, bytesRead, nil)
+      if rres == 0:
+        let errCode = ioLastError()
+        discard setConsoleCP(prevInputCP)
+        return err(errCode)
+
+      if setConsoleCP(prevInputCP) == 0'i32:
+        return err(ioLastError())
+
+      # Truncate additional bytes from buffer.
+      buffer.setLen(int(min(bytesRead, uint32(maxBytes))))
+
+      # Trim CR/CRLF from buffer.
+      if len(buffer) > 0:
+        if buffer[^1] == char(0x0A):
+          if len(buffer) > 1:
+            if buffer[^2] == char(0x0D):
+              buffer.setLen(len(buffer) - 2)
+            else:
+              buffer.setLen(len(buffer) - 1)
+          else:
+            buffer.setLen(len(buffer) - 1)
+        elif buffer[^1] == char(0x0D):
+          buffer.setLen(len(buffer) - 1)
+      ok(buffer)
+    else:
+      let prevMode =
+        block:
+          var mode: uint32
+          let res = getConsoleMode(hConsoleInput, mode)
+          if res == 0:
+            return err(ioLastError())
+          mode
+
+      var newMode = prevMode or ENABLE_PROCESSED_INPUT
+      newMode = newMode and not(ENABLE_ECHO_INPUT)
+
+      # Change console CodePage to allow UTF-8 strings input.
+      if setConsoleCP(CP_UTF8) == 0'i32:
+        return err(ioLastError())
+
+      # Disable local echo output.
+      let mres = setConsoleMode(hConsoleInput, newMode)
+      if mres == 0:
+        let errCode = ioLastError()
+        discard setConsoleCP(prevInputCP)
+        return err(errCode)
+
+      # Allocating buffer with size equal to `maxBytes` + len(CRLF)
+      var buffer = newSeq[Utf16Char](maxBytes + 2)
+      let charsToRead = uint32(len(buffer))
+      var charsRead: uint32
+      let rres = readConsole(hConsoleInput, cast[pointer](addr buffer[0]),
+                             charsToRead, charsRead, nil)
+      if rres == 0'i32:
+        let errCode = ioLastError()
+        discard setConsoleMode(hConsoleInput, prevMode)
+        discard setConsoleCP(prevInputCP)
+        return err(errCode)
+
+      # Restore local echo output.
+      if setConsoleMode(hConsoleInput, prevMode) == 0'i32:
+        let errCode = ioLastError()
+        discard setConsoleCP(prevInputCP)
+        return err(errCode)
+
+      # Restore previous console CodePage.
+      if setConsoleCP(prevInputCP) == 0'i32:
+        return err(ioLastError())
+
+      # Truncate additional bytes from buffer.
+      buffer.setLen(int(min(charsRead, uint32(maxBytes))))
+      # Truncate CRLF in result wide string.
+      if len(buffer) > 0:
+        if int16(buffer[^1]) == int16(0x0A):
+          if len(buffer) > 1:
+            if int16(buffer[^2]) == int16(0x0D):
+              buffer.setLen(len(buffer) - 2)
+            else:
+              buffer.setLen(len(buffer) - 1)
+          else:
+            buffer.setLen(len(buffer) - 1)
+        elif int16(buffer[^1]) == int16(0x0D):
+          buffer.setLen(len(buffer) - 1)
+
+      # Convert Windows UTF-16 encoded string to UTF-8 encoded string.
+      if len(buffer) > 0:
+        var pwd = ""
+        let bytesNeeded = wideCharToMultiByte(CP_UTF8, 0'u32, addr buffer[0],
+                                              cint(len(buffer)), nil,
+                                              cint(0), nil, nil)
+        if bytesNeeded <= cint(0):
+          return err(ioLastError())
+        pwd.setLen(bytesNeeded)
+        let cres = wideCharToMultiByte(CP_UTF8, 0'u32, addr buffer[0],
+                                       cint(len(buffer)), addr pwd[0],
+                                       cint(len(pwd)), nil, nil)
+        if cres == cint(0):
+          return err(ioLastError())
+        ok(pwd)
+      else:
+        ok("")
+
+  proc writeConsoleOutput(data: string): IoResult[void] =
+    if len(data) == 0:
+      return ok()
+
+    let hConsoleOutput =
+      block:
+        let res = getStdHandle(STD_OUTPUT_HANDLE)
+        if res == INVALID_HANDLE_VALUE:
+          return err(ioLastError())
+        res
+
+    let prevOutputCP =
+      block:
+        let res = getConsoleOutputCP()
+        if res == cuint(0):
+          return err(ioLastError())
+        res
+
+    if isConsoleRedirected(hConsoleOutput):
+      # If STDOUT is redirected we should use WriteFile() because WriteConsole()
+      # is not working for such types of STDOUT.
+      if setConsoleOutputCP(CP_UTF8) == 0'i32:
+        return err(ioLastError())
+
+      let bytesToWrite = uint32(len(data))
+      var bytesWritten: uint32
+      let wres = writeFile(hConsoleOutput, cast[pointer](unsafeAddr data[0]),
+                           bytesToWrite, bytesWritten, nil)
+      if wres == 0'i32:
+        let errCode = ioLastError()
+        discard setConsoleOutputCP(prevOutputCP)
+        return err(errCode)
+
+      if setConsoleOutputCP(prevOutputCP) == 0'i32:
+        return err(ioLastError())
+    else:
+      if setConsoleOutputCP(CP_UTF8) == 0'i32:
+        return err(ioLastError())
+
+      let widePrompt = newWideCString(data)
+      var charsWritten: uint32
+      let wres = writeConsole(hConsoleOutput, cast[pointer](widePrompt),
+                              uint32(len(widePrompt)), charsWritten, nil)
+      if wres == 0'i32:
+        let errCode = ioLastError()
+        discard setConsoleOutputCP(prevOutputCP)
+        return err(errCode)
+
+      if setConsoleOutputCP(prevOutputCP) == 0'i32:
+        return err(ioLastError())
+    ok()
+
+elif defined(posix):
+  import posix, termios
+
+  proc isConsoleRedirected(consoleFd: cint): bool =
+    ## Returns ``true`` if console handle was redirected.
+    var mode: Termios
+    if tcGetAttr(consoleFd, addr mode) != cint(0):
+      let errCode = ioLastError()
+      if errCode == ENOTTY:
+        true
+      else:
+        false
+    else:
+      false
+
+  proc writeConsoleOutput(prompt: string): IoResult[void] =
+    if len(prompt) == 0:
+      ok()
+    else:
+      let res = posix.write(STDOUT_FILENO, cast[pointer](unsafeAddr prompt[0]),
+                            len(prompt))
+      if res != len(prompt):
+        err(ioLastError())
+      else:
+        ok()
+
+  proc readConsoleInput(maxBytes: int): IoResult[string] =
+    # Allocating buffer with size equal to `maxBytes` + len(LF)
+    var buffer = newString(maxBytes + 1)
+    let bytesRead =
+      if isConsoleRedirected(STDIN_FILENO):
+        let res = posix.read(STDIN_FILENO, cast[pointer](addr buffer[0]),
+                             len(buffer))
+        if res < 0:
+          return err(ioLastError())
+        res
+      else:
+        var cur, old: Termios
+        if tcGetAttr(STDIN_FILENO, addr cur) != cint(0):
+          return err(ioLastError())
+
+        old = cur
+        cur.c_lflag = cur.c_lflag and not(Cflag(ECHO))
+
+        if tcSetAttr(STDIN_FILENO, TCSADRAIN, addr(cur)) != cint(0):
+          return err(ioLastError())
+
+        let res = read(STDIN_FILENO, cast[pointer](addr buffer[0]),
+                       len(buffer))
+        if res < 0:
+          discard tcSetAttr(STDIN_FILENO, TCSADRAIN, addr(old))
+          return err(ioLastError())
+
+        if tcSetAttr(STDIN_FILENO, TCSADRAIN, addr(old)) != cint(0):
+          return err(ioLastError())
+        res
+
+    # Truncate additional bytes from buffer.
+    buffer.setLen(min(maxBytes, bytesRead))
+    # Trim LF in result string
+    if len(buffer) > 0:
+      if buffer[^1] == char(0x0A):
+        buffer.setLen(len(buffer) - 1)
+    ok(buffer)
+
+proc readConsolePassword*(prompt: string,
+                          maxBytes = 32768): IoResult[string] =
+  ## Reads a password from stdin without printing it with length in bytes up to
+  ## ``maxBytes``.
+  ##
+  ## This procedure supports reading of UTF-8 encoded passwords from console or
+  ## redirected pipe. But ``maxBytes`` will limit
+  ##
+  ## Before reading password ``prompt`` will be printed.
+  ##
+  ## Please note that ``maxBytes`` should be in range (0, 32768].
+  doAssert(maxBytes > 0 and maxBytes <= 32768,
+           "maxBytes should be integer in (0, 32768]")
+  ? writeConsoleOutput(prompt)
+  let res = ? readConsoleInput(maxBytes)
+  # `\p` is platform specific newline: CRLF on Windows, LF on Unix
+  ? writeConsoleOutput("\p")
+  ok(res)

--- a/stew/utf8.nim
+++ b/stew/utf8.nim
@@ -1,0 +1,91 @@
+## Copyright (c) 2020 Status Research & Development GmbH
+## Licensed under either of
+##  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE))
+##  * MIT license ([LICENSE-MIT](LICENSE-MIT))
+## at your option.
+## This file may not be copied, modified, or distributed except according to
+## those terms.
+
+## This module implements UTF-8 related procedures.
+
+proc validateUtf8*[T: byte|char](data: openarray[T]): bool =
+  ## Returns ``true`` if ``data`` is correctly UTF-8 encoded string.
+  var index = 0
+
+  while true:
+    let byte1 =
+      block:
+        var b: byte
+        while true:
+          if index >= len(data):
+            return true
+          b = when T is byte: data[index] else: byte(data[index])
+          inc(index)
+          if b >= 0x80'u8:
+            break
+        b
+
+    if (byte1 and 0xE0'u8) == 0xC0'u8:
+      # Two-byte form (110xxxxx 10xxxxxx)
+      if index >= len(data):
+        return false
+      # overlong sequence test
+      if (byte1 and 0xFE'u8) == 0xC0'u8:
+        return false
+
+      let byte2 = when T is byte: data[index] else: byte(data[index])
+      if (byte2 and 0xC0'u8) != 0x80'u8:
+        return false
+      inc(index)
+
+    elif (byte1 and 0xF0'u8) == 0xE0'u8:
+      # Three-byte form (1110xxxx 10xxxxxx 10xxxxxx)
+      if (index + 1) >= len(data):
+        return false
+
+      let byte2 = when T is byte: data[index] else: byte(data[index])
+      if (byte2 and 0xC0'u8) != 0x80'u8:
+        return false
+      # overlong sequence test
+      if (byte1 == 0xE0'u8) and ((byte2 and 0xE0'u8) == 0x80'u8):
+        return false
+      #  0xD800–0xDFFF (UTF-16 surrogates) test
+      if (byte1 == 0xED'u8) and ((byte2 and 0xE0'u8) == 0xA0'u8):
+        return false
+
+      let byte3 = when T is byte: data[index + 1] else: byte(data[index + 1])
+      if (byte3 and 0xC0'u8) != 0x80'u8:
+        return false
+      # U+FFFE or U+FFFF test
+      if (byte1 == 0xEF'u8) and (byte2 == 0xBF'u8) and
+         ((byte3 and 0xFE'u8) == 0xBE'u8):
+        return false
+      inc(index, 2)
+
+    elif (byte1 and 0xF8'u8) == 0xF0'u8:
+      # Four-byte form (11110xxx 10xxxxxx 10xxxxxx 10xxxxxx)
+      if (index + 2) >= len(data):
+        return false
+
+      let byte2 = when T is byte: data[index] else: byte(data[index])
+      if (byte2 and 0xC0'u8) != 0x80'u8:
+        return false
+      # overlong sequence test
+      if (byte1 == 0xF0'u8) and ((byte2 and 0xF0'u8) == 0x80'u8):
+        return false
+      # According to RFC 3629 no point above U+10FFFF should be used, which
+      # limits characters to four bytes.
+      if ((byte1 == 0xF4'u8) and (byte2 > 0x8F'u8)) or (byte1 > 0xF4'u8):
+        return false
+
+      let byte3 = when T is byte: data[index + 1] else: byte(data[index + 1])
+      if (byte3 and 0xC0'u8) != 0x80'u8:
+        return false
+
+      let byte4 = when T is byte: data[index + 2] else: byte(data[index + 2])
+      if (byte4 and 0xC0'u8) != 0x80'u8:
+        return false
+      inc(index, 3)
+
+    else:
+      return false

--- a/stew/utf8.nim
+++ b/stew/utf8.nim
@@ -414,8 +414,8 @@ when defined(posix):
                  ps: ptr Mbstate): csize_t {.
        importc, header: "<wchar.h>".}
 
-  proc mbstowcs*[A: Bytes, B: Wides](t: typedesc[B],
-                                     input: openarray[A]): UResult[seq[B]] =
+  proc mbstowcs*[A: Bytes, B: Wides32](t: typedesc[B],
+                                       input: openarray[A]): UResult[seq[B]] =
     ## Converts multibyte encoded string to OS specific wide char string.
     ##
     ## Note, that `input` should be `0` terminated.

--- a/stew/utf8.nim
+++ b/stew/utf8.nim
@@ -12,7 +12,8 @@ export results
 
 type
   UResult*[T] = Result[T, cstring]
-  Wides* = int16 | uint16 | int32 | uint32
+  Wides32* = int32 | uint32
+  Wides16* = int16 | uint16
   Bytes* = int8 | char | uint8 | byte
 
 const
@@ -206,72 +207,200 @@ proc utf8Substr*[T: Bytes](data: openarray[T],
     inc(k)
   ok(res)
 
-proc wcharToUtf8*[A: Wides, B: Bytes](input: openarray[A],
+proc utf32toUtf8*[A: Wides32, B: Bytes](input: openarray[A],
                                       output: var openarray[B]): UResult[int] =
-  ## Converts WCHAR sequence ``input`` to UTF-8 array of octets ``output``.
-  ##
-  ## Procedure supports 4-byte (Linux) and 2-byte sequences (Windows) as input.
+  ## Converts UTF-32 sequence ``input`` to UTF-8 array ``output``.
   var offset = 0
   for item in input:
-    let uitem = uint(item)
     let codepoint =
-      if uitem >= 0xD800'u and uitem <= 0xDBFF'u:
-        0x10000'u + ((uitem - 0xD800'u) shl 10)
-      else:
-        if uitem >= 0xDC00'u and uitem <= 0xDFFF'u:
-          uitem - 0xDC00'u
-        else:
-          uitem
-    if codepoint <= 0x7F'u:
+      block:
+        if (uint32(item) >= 0xD800'u32) and (uint32(item) <= 0xDFFF'u32):
+          # high and low surrogates U+D800 through U+DFFF prohibited in UTF-32.
+          return err(ErrorInvalidSequence)
+        elif (uint32(item) == 0xFFFE'u32) or (uint32(item) == 0xFFFF'u32):
+          # these codes are intended for process-internal uses, and not a
+          # unicode characters.
+          return err(ErrorInvalidSequence)
+        uint32(item)
+    if codepoint <= 0x7F'u32:
       if len(output) > 0:
         if offset < len(output):
-          output[offset] = cast[B](codepoint and 0x7F'u)
+          output[offset] = cast[B](codepoint and 0x7F'u32)
         else:
           return err(ErrorBufferOverflow)
       inc(offset, 1)
-    elif codepoint <= 0x7FF'u:
+    elif codepoint <= 0x7FF'u32:
       if len(output) > 0:
         if offset + 1 < len(output):
           output[offset + 0] = cast[B](0xC0'u8 or
-                                       byte((codepoint shr 6) and 0x1F'u))
-          output[offset + 1] = cast[B](0x80'u8 or byte(codepoint and 0x3F'u))
+                                       byte((codepoint shr 6) and 0x1F'u32))
+          output[offset + 1] = cast[B](0x80'u8 or byte(codepoint and 0x3F'u32))
         else:
           return err(ErrorBufferOverflow)
       inc(offset, 2)
-    elif codepoint <= 0xFFFF'u:
+    elif codepoint <= 0xFFFF'u32:
       if len(output) > 0:
         if offset + 2 < len(output):
           output[offset + 0] = cast[B](0xE0'u8 or
-                                       byte((codepoint shr 12) and 0x0F'u))
+                                       byte((codepoint shr 12) and 0x0F'u32))
           output[offset + 1] = cast[B](0x80'u8 or
-                                       byte((codepoint shr 6) and 0x3F'u))
-          output[offset + 2] = cast[B](0x80'u8 or byte(codepoint and 0x3F'u))
+                                       byte((codepoint shr 6) and 0x3F'u32))
+          output[offset + 2] = cast[B](0x80'u8 or byte(codepoint and 0x3F'u32))
         else:
           return err(ErrorBufferOverflow)
       inc(offset, 3)
-    elif codepoint <= 0x10FFFF'u:
+    elif codepoint <= 0x10FFFF'u32:
       if len(output) > 0:
         if offset + 3 < len(output):
           output[offset + 0] = cast[B](0xF0'u8 or
-                                       byte((codepoint shr 18) and 0x07'u))
+                                       byte((codepoint shr 18) and 0x07'u32))
           output[offset + 1] = cast[B](0x80'u8 or
-                                       byte((codepoint shr 12) and 0x3F'u))
+                                       byte((codepoint shr 12) and 0x3F'u32))
           output[offset + 2] = cast[B](0x80'u8 or
-                                       byte((codepoint shr 6) and 0x3F'u))
-          output[offset + 3] = cast[B](0x80'u8 or byte(codepoint and 0x3F'u))
+                                       byte((codepoint shr 6) and 0x3F'u32))
+          output[offset + 3] = cast[B](0x80'u8 or byte(codepoint and 0x3F'u32))
         else:
-          return err("")
+          return err(ErrorBufferOverflow)
       inc(offset, 4)
     else:
       return err(ErrorInvalidSequence)
   ok(offset)
 
-proc wcharToUtf8*[T: Wides](input: openarray[T]): UResult[string] {.inline.} =
-  ## Converts wide character
+proc utf32toUtf8*[T: Wides32](input: openarray[T]): UResult[string] {.inline.} =
+  ## Converts wide character sequence ``input`` to UTF-8 encoded string.
   var empty: array[0, char]
-  let size = ? wcharToUtf8(input, empty)
+  let size = ? utf32ToUtf8(input, empty)
   var output = newString(size)
-  let res {.used.} = ? wcharToUtf8(input, output)
+  let res {.used.} = ? utf32ToUtf8(input, output)
+  ok(output)
+
+proc utf8toUtf32*[A: Bytes, B: Wides32](input: openarray[A],
+                                       output: var openarray[B]): UResult[int] =
+  ## Convert UTF-8 encoded array of characters ``input`` to UTF-32 encoded
+  ## sequences of 32bit limbs.
+  ##
+  ## To obtain required size of ``output`` you need to pass ``output`` as
+  ## zero-length array, in such way required size will be returned as result of
+  ## procedure.
+  ##
+  ## If size of ``output`` is not zero, and there not enough space in ``output``
+  ## array to store whole ``input`` array, error ``ErrorBufferOverflow`` will
+  ## be returned.
+  var index = 0
+  var dindex = 0
+  if len(output) == 0:
+    return utf8Length(input)
+  else:
+    while true:
+      if index >= len(input):
+        break
+      let byte1 = uint32(input[index])
+      inc(index)
+
+      if (byte1 and 0x80) == 0x00:
+        if dindex < len(output):
+          output[dindex] = B(byte1)
+          inc(dindex)
+        else:
+          return err(ErrorBufferOverflow)
+      elif (byte1 and 0xE0'u32) == 0xC0'u32:
+        # Two-byte form (110xxxxx 10xxxxxx)
+        if index >= len(input):
+          return err(ErrorInvalidSequence)
+        # overlong sequence test
+        if (byte1 and 0xFE'u32) == 0xC0'u32:
+          return err(ErrorInvalidSequence)
+
+        let byte2 = uint32(input[index])
+        if (byte2 and 0xC0'u32) != 0x80'u32:
+          return err(ErrorInvalidSequence)
+
+        if dindex < len(output):
+          output[dindex] = B(((byte1 and 0x1F'u32) shl 6) or
+                              (byte2 and 0x3F'u32))
+          inc(dindex)
+        else:
+          return err(ErrorBufferOverflow)
+        inc(index)
+      elif (byte1 and 0xF0'u32) == 0xE0'u32:
+        # Three-byte form (1110xxxx 10xxxxxx 10xxxxxx)
+        if (index + 1) >= len(input):
+          return err(ErrorInvalidSequence)
+
+        let byte2 = uint32(input[index])
+        if (byte2 and 0xC0'u32) != 0x80'u32:
+          return err(ErrorInvalidSequence)
+        # overlong sequence test
+        if (byte1 == 0xE0'u32) and ((byte2 and 0xE0'u32) == 0x80'u32):
+          return err(ErrorInvalidSequence)
+        #  0xD800–0xDFFF (UTF-16 surrogates) test
+        if (byte1 == 0xED'u32) and ((byte2 and 0xE0'u32) == 0xA0'u32):
+          return err(ErrorInvalidSequence)
+
+        let byte3 = uint32(input[index + 1])
+        if (byte3 and 0xC0'u32) != 0x80'u32:
+          return err(ErrorInvalidSequence)
+        # U+FFFE or U+FFFF test
+        if (byte1 == 0xEF'u32) and (byte2 == 0xBF'u32) and
+           ((byte3 and 0xFE'u32) == 0xBE'u32):
+          return err(ErrorInvalidSequence)
+
+        if dindex < len(output):
+          output[dindex] = B(((byte1 and 0x0F'u32) shl 12) or
+                             ((byte2 and 0x3F'u32) shl 6) or
+                              (byte3 and 0x3F'u32))
+          inc(dindex)
+        else:
+          return err(ErrorBufferOverflow)
+        inc(index, 2)
+
+      elif (byte1 and 0xF8'u8) == 0xF0'u8:
+        # Four-byte form (11110xxx 10xxxxxx 10xxxxxx 10xxxxxx)
+        if (index + 2) >= len(input):
+          return err(ErrorInvalidSequence)
+
+        let byte2 = uint32(input[index])
+        if (byte2 and 0xC0'u32) != 0x80'u32:
+          return err(ErrorInvalidSequence)
+        # overlong sequence test
+        if (byte1 == 0xF0'u32) and ((byte2 and 0xF0'u32) == 0x80'u32):
+          return err(ErrorInvalidSequence)
+        # According to RFC 3629 no point above U+10FFFF should be used, which
+        # limits characters to four bytes.
+        if ((byte1 == 0xF4'u32) and (byte2 > 0x8F'u32)) or (byte1 > 0xF4'u32):
+          return err(ErrorInvalidSequence)
+
+        let byte3 = uint32(input[index + 1])
+        if (byte3 and 0xC0'u32) != 0x80'u32:
+          return err(ErrorInvalidSequence)
+
+        let byte4 = uint32(input[index + 2])
+        if (byte4 and 0xC0'u32) != 0x80'u32:
+          return err(ErrorInvalidSequence)
+
+        if dindex < len(output):
+          output[dindex] = B(((byte1 and 0x07'u32) shl 18) or
+                             ((byte2 and 0x3F'u32) shl 12) or
+                             ((byte3 and 0x3F'u32) shl 6) or
+                              (byte4 and 0x3F'u32))
+          inc(dindex)
+        else:
+          return err(ErrorBufferOverflow)
+        inc(index, 3)
+
+      else:
+        return err(ErrorInvalidSequence)
+
+    ok(dindex)
+
+proc utf8toUtf32*[A: Bytes, B: Wides32](et: typedesc[B],
+                                        input: openarray[A]): UResult[seq[B]] =
+  ## Convert UTF-8 encoded array of characters ``input`` to UTF-32 encoded
+  ## sequence of 32bit limbs and return it.
+  var empty: array[0, B]
+  let size = ? utf8toUtf32(input, empty)
+  var output = newSeq[B](size)
+  let res {.used.} = ? utf8toUtf32(input, output)
   ok(output)
 
 when defined(posix):

--- a/tests/all_tests.nim
+++ b/tests/all_tests.nim
@@ -23,4 +23,5 @@ import
   test_varints,
   test_ctops,
   test_io2,
-  test_winacl
+  test_winacl,
+  test_utf8

--- a/tests/test_utf8.nim
+++ b/tests/test_utf8.nim
@@ -1,0 +1,193 @@
+import std/unittest
+import ../stew/utf8
+
+proc toUTF4(value: uint32): array[4, byte] =
+  doAssert(value >= 0x10000'u32 and value < 0x200000'u32)
+  [
+    0xF0'u8 or byte((value shr 18) and 0x07),
+    0x80'u8 or byte((value shr 12) and 0x3F),
+    0x80'u8 or byte((value shr 6) and 0x3F),
+    0x80'u8 or byte(value and 0x3F)
+  ]
+
+proc toUTF3(value: uint32): array[3, byte] =
+  doAssert(value >= 0x800'u32 and value < 0x10000'u32)
+  [
+    0xE0'u8 or byte((value shr 12) and 0x0F),
+    0x80'u8 or byte((value shr 6) and 0x3F),
+    0x80'u8 or byte(value and 0x3F)
+  ]
+
+proc toUTF2(value: uint32): array[2, byte] =
+  doAssert(value >= 0x80'u32 and value < 0x800'u32)
+  [
+    0xC0'u8 or byte((value shr 6) and 0x1F),
+    0x80'u8 or byte(value and 0x3F)
+  ]
+
+proc toUTF1(value: uint32): array[1, byte] =
+  doAssert(value < 0x80'u32)
+  [ byte(value and 0x7F) ]
+
+suite "UTF-8 validation test suite":
+  test "Values [U+0000, U+007F] are allowed":
+    for i in 0x00'u32 .. 0x7F'u32:
+      check validateUtf8(toUTF1(i)) == true
+  test "Values [U+0080, U+07FF] are allowed":
+    for i in 0x80'u32 .. 0x7FF'u32:
+      check validateUtf8(toUTF2(i)) == true
+  test "Values [U+0800, U+D7FF] are allowed":
+    for i in 0x800'u32 .. 0xD7FF'u32:
+      check validateUtf8(toUTF3(i)) == true
+  test "Values [U+D800, U+DFFF] (UTF-16 surrogates) are not allowed":
+    for i in 0xD800'u32 .. 0xDFFF'u32:
+      check validateUtf8(toUTF3(i)) == false
+  test "Values [U+E000, U+FFFD] are allowed":
+    for i in 0xE000'u32 .. 0xFFFD'u32:
+      check validateUtf8(toUTF3(i)) == true
+  test "Values U+FFFE and U+FFFF are not allowed":
+    check:
+      validateUtf8(toUTF3(0xFFFE'u32)) == false
+      validateUtf8(toUTF3(0xFFFF'u32)) == false
+  test "Values [U+10000, U10FFFF] are allowed":
+    for i in 0x10000'u32 .. 0x10FFFF'u32:
+      check validateUtf8(toUTF4(i)) == true
+  test "Values bigger U+10FFFF are not allowed":
+    for i in 0x11_0000'u32 .. 0x1F_FFFF'u32:
+      check validateUtf8(toUTF4(i)) == false
+  test "fastvalidate-utf-8 bad sequences":
+    # https://github.com/lemire/fastvalidate-utf-8 test vectors
+    const
+      GoodSequences = [
+        "a",
+        "\xc3\xb1",
+        "\xe2\x82\xa1",
+        "\xf0\x90\x8c\xbc",
+        "안녕하세요, 세상",
+        "\xc2\x80",
+        "\xf0\x90\x80\x80",
+        "\xee\x80\x80"
+      ]
+
+      BadSequences = [
+        "\xc3\x28",
+        "\xa0\xa1",
+        "\xe2\x28\xa1",
+        "\xe2\x82\x28",
+        "\xf0\x28\x8c\xbc",
+        "\xf0\x90\x28\xbc",
+        "\xf0\x28\x8c\x28",
+        "\xc0\x9f",
+        "\xf5\xff\xff\xff",
+        "\xed\xa0\x81",
+        "\xf8\x90\x80\x80\x80",
+        "123456789012345\xed",
+        "123456789012345\xf1",
+        "123456789012345\xc2",
+        "\xC2\x7F",
+        "\xce",
+        "\xce\xba\xe1",
+        "\xce\xba\xe1\xbd",
+        "\xce\xba\xe1\xbd\xb9\xcf",
+        "\xce\xba\xe1\xbd\xb9\xcf\x83\xce",
+        "\xce\xba\xe1\xbd\xb9\xcf\x83\xce\xbc\xce",
+        "\xdf",
+        "\xef\xbf"
+      ]
+    for item in BadSequences:
+      check validateUtf8(item) == false
+    for item in GoodSequences:
+      check validateUtf8(item) == true
+  test "UTF-8 decoder capability and stress test":
+    # https://www.cl.cam.ac.uk/~mgk25/ucs/examples/UTF-8-test.txt
+    const Tests2 = [
+      # Boundary condition test cases
+      ("\x00", true),
+      ("\xc2\x80", true),
+      ("\xe0\xa0\x80", true),
+      ("\xf0\x90\x80\x80", true),
+      ("\xf8\x88\x80\x80\x80", false),
+      ("\xfc\x84\x80\x80\x80\x80", false),
+      ("\x7f", true),
+      ("\xdf\xbf", true),
+      ("\xef\xbf\xbf", false),
+      ("\xf7\xbf\xbf\xbf", false),
+      ("\xfb\xbf\xbf\xbf\xbf", false),
+      ("\xfd\xbf\xbf\xbf\xbf\xbf", false),
+      ("\xed\x9f\xbf", true),
+      ("\xee\x80\x80", true),
+      ("\xef\xbf\xbd", true),
+      ("\xf4\x8f\xbf\xbf", true),
+    ]
+
+    const Tests3 = [
+      # Malformed sequences
+      ("\x80", false),
+      ("\xbf", false),
+      ("\x80\xbf", false),
+      ("\x80\xbf\x80", false),
+      ("\x80\xbf\x80\xbf", false),
+      ("\x80\xbf\x80\xbf\x80", false),
+      ("\x80\xbf\x80\xbf\x80\xbf", false),
+      ("\x80\xbf\x80\xbf\x80\xbf\x80", false),
+      ("\xc0", false),
+      ("\xe0\x80", false),
+      ("\xf0\x80\x80", false),
+      ("\xf8\x80\x80\x80", false),
+      ("\xfc\x80\x80\x80\x80", false),
+      ("\xdf", false),
+      ("\xef\xbf", false),
+      ("\xf7\xbf\xbf", false),
+      ("\xfb\xbf\xbf\xbf", false),
+      ("\xfd\xbf\xbf\xbf\xbf", false),
+      ("\xfe", false),
+      ("\xff", false),
+      ("\xfe\xfe\xff\xff", false)
+    ]
+
+    const Tests4 = [
+      # Overlong sequences
+      ("\xc0\xaf", false),
+      ("\xe0\x80\xaf", false),
+      ("\xf0\x80\x80\xaf", false),
+      ("\xf8\x80\x80\x80\xaf", false),
+      ("\xfc\x80\x80\x80\x80\xaf", false),
+      ("\xc1\xbf", false),
+      ("\xe0\x9f\xbf", false),
+      ("\xf0\x8f\xbf\xbf", false),
+      ("\xf8\x87\xbf\xbf\xbf", false),
+      ("\xfc\x83\xbf\xbf\xbf\xbf", false),
+      ("\xc0\x80", false),
+      ("\xe0\x80\x80", false),
+      ("\xf0\x80\x80\x80", false),
+      ("\xf8\x80\x80\x80\x80", false),
+      ("\xfc\x80\x80\x80\x80\x80", false)
+    ]
+
+    const Tests5 = [
+      # Illegal code positions
+      ("\xed\xa0\x80", false),
+      ("\xed\xad\xbf", false),
+      ("\xed\xae\x80", false),
+      ("\xed\xaf\xbf", false),
+      ("\xed\xb0\x80", false),
+      ("\xed\xbe\x80", false),
+      ("\xed\xbf\xbf", false),
+      ("\xed\xa0\x80\xed\xb0\x80", false),
+      ("\xed\xa0\x80\xed\xbf\xbf", false),
+      ("\xed\xad\xbf\xed\xb0\x80", false),
+      ("\xed\xad\xbf\xed\xbf\xbf", false),
+      ("\xed\xae\x80\xed\xb0\x80", false),
+      ("\xed\xae\x80\xed\xbf\xbf", false),
+      ("\xed\xaf\xbf\xed\xb0\x80", false),
+      ("\xed\xaf\xbf\xed\xbf\xbf", false)
+    ]
+
+    for item in Tests2:
+      check validateUtf8(item[0]) == item[1]
+    for item in Tests3:
+      check validateUtf8(item[0]) == item[1]
+    for item in Tests4:
+      check validateUtf8(item[0]) == item[1]
+    for item in Tests5:
+      check validateUtf8(item[0]) == item[1]


### PR DESCRIPTION
Different console procedures which are missing or not properly implemented in Nim' stdlib.
Current PR introduces cross-platform password reading procedure which:
1. Supports reading of UTF-8 passwords. (Does not supported on Nim 1.2.6 stdlib).
2. Supports reading from both console and redirected stdin. (Does not supported on Nim devel stdlib).
3. Supports password size limitation (Removes attack vector which is present in Nim 1.2.6/devel stdlib).
4. Do not raise exceptions (Uses io2.IoResult[T]).
