### PR TITLE
fixes bitops2: 'countOnesBuiltin' and 'parityBuiltin' when feed 'un…

### DIFF
--- a/stew/bitops2.nim
+++ b/stew/bitops2.nim
@@ -158,15 +158,15 @@ when (defined(gcc) or defined(llvm_gcc) or defined(clang)) and useBuiltins:
 
   func countOnesBuiltin(x: SomeUnsignedInt): int =
     when bitsof(x) == bitsof(culonglong):
-      builtin_popcountll(x).int
+      builtin_popcountll(x.culonglong).int
     else:
-      builtin_popcount(x).int
+      builtin_popcount(x.cuint).int
 
   func parityBuiltin(x: SomeUnsignedInt): int =
     when bitsof(x) == bitsof(culonglong):
-      builtin_parityll(x)
+      builtin_parityll(x.culonglong).int
     else:
-      builtin_parity(x)
+      builtin_parity(x.cuint).int
 
   func firstOneBuiltin(x: SomeUnsignedInt): int =
     when bitsof(x) == bitsof(clonglong):

--- a/tests/test_bitops2.nim
+++ b/tests/test_bitops2.nim
@@ -9,6 +9,7 @@ template test() =
   doAssert countOnes(0b00000000'u8) == 0
   doAssert countOnes(0b01000100'u8) == 2
   doAssert countOnes(0b11111111'u64) == 8
+  doAssert countOnes(0b11000001'u) == 3
 
   doAssert firstOne(0b00000000'u8) == 0
   doAssert firstOne(0b00000001'u64) == 1
@@ -16,6 +17,7 @@ template test() =
   doAssert firstOne(0b11111111'u8) == 1
   doAssert firstOne(0b100000000000000000000000000000000'u64) == 33
   doAssert firstOne(0b00000010_00000000_00000000_00000000_00000000_00000000_00000000_00000000'u64) == 8*7 + 2
+  doAssert firstOne(0b11111111'u) == 1
 
   doAssert leadingZeros(0b00000000'u8) == 8
   doAssert leadingZeros(0b00000001'u8) == 7
@@ -24,6 +26,10 @@ template test() =
   doAssert leadingZeros(0b10000000'u16) == 8
   doAssert leadingZeros(0b10000000'u32) == 24
   doAssert leadingZeros(0b10000000'u64) == 56
+  when defined(cpu64):
+    doAssert leadingZeros(0b00000001'u) == 63
+  else:
+    doAssert leadingZeros(0b00000001'u) == 31
 
   doAssert log2trunc(0b00000000'u8) == -1
   doAssert log2trunc(0b00000001'u8) == 0
@@ -31,16 +37,21 @@ template test() =
   doAssert log2trunc(0b01000000'u8) == 6
   doAssert log2trunc(0b01001000'u8) == 6
   doAssert log2trunc(0b10001000'u64) == 7
+  doAssert log2trunc(0b01000000'u) == 6
 
   doAssert nextPow2(0'u64) == 0
   doAssert nextPow2(3'u64) == 4
   doAssert nextPow2(4'u32) == 4
+  doAssert nextPow2(4'u) == 4
 
   doAssert parity(0b00000001'u8) == 1
   doAssert parity(0b10000001'u64) == 0
+  doAssert parity(0b00000001'u) == 1
 
   doAssert rotateLeft(0b01000001'u8, 2) == 0b00000101'u8
   doAssert rotateRight(0b01000001'u8, 2) == 0b01010000'u8
+  doAssert rotateLeft(0b01000001'u, 2) == 0b100000100'u
+  doAssert rotateRight(0b0100000100'u, 2) == 0b01000001'u
 
   doAssert trailingZeros(0b00000000'u8) == 8
   doAssert trailingZeros(0b00100000'u8) == 5
@@ -49,6 +60,7 @@ template test() =
   doAssert trailingZeros(0b10000000'u16) == 7
   doAssert trailingZeros(0b10000000'u32) == 7
   doAssert trailingZeros(0b10000000'u64) == 7
+  doAssert trailingZeros(0b10000000'u) == 7
 
   var bit: uint8
   setBit(bit, 0)


### PR DESCRIPTION
…signed' on 32 bit platform