### PR TITLE
add uint support in endians2 to match beacon_chain/ssz/bitseqs

### DIFF
--- a/tests/test_endians2.nim
+++ b/tests/test_endians2.nim
@@ -3,17 +3,34 @@ import unittest
 import ../stew/endians2
 
 template test() =
+  when sizeof(uint) == 4:
+    const
+      forwardInt = 0x01234567'u
+      forwardBytes = [0x01'u8, 0x23'u8, 0x45'u8, 0x67'u8]
+      reverseBytes = [0x67'u8, 0x45'u8, 0x23'u8, 0x01'u8]
+  elif sizeof(uint) == 8:
+    const
+      forwardInt = 0x0123456789abcdef'u
+      forwardBytes = [
+        0x01'u8, 0x23'u8, 0x45'u8, 0x67'u8, 0x89'u8, 0xab'u8, 0xcd'u8, 0xef'u8]
+      reverseBytes = [
+        0xef'u8, 0xcd'u8, 0xab'u8, 0x89'u8, 0x67'u8, 0x45'u8, 0x23'u8, 0x01'u8]
+  else:
+    static: doAssert false, "requires a 32-bit or 64-bit platform"
+
   doAssert 0x01'u8.toBytesBE == [0x01'u8]
   doAssert 0x0123'u16.toBytesBE == [0x01'u8, 0x23'u8]
   doAssert 0x01234567'u32.toBytesBE == [0x01'u8, 0x23'u8, 0x45'u8, 0x67'u8]
   doAssert 0x0123456789abcdef'u64.toBytesBE == [
     0x01'u8, 0x23'u8, 0x45'u8, 0x67'u8, 0x89'u8, 0xab'u8, 0xcd'u8, 0xef'u8]
+  doAssert forwardInt.toBytesBE == forwardBytes
 
   doAssert 0x01'u8.toBytesLE == [0x01'u8]
   doAssert 0x0123'u16.toBytesLE == [0x23'u8, 0x01'u8]
   doAssert 0x01234567'u32.toBytesLE == [0x67'u8, 0x45'u8, 0x23'u8, 0x01'u8]
   doAssert 0x0123456789abcdef'u64.toBytesLE == [
     0xef'u8, 0xcd'u8, 0xab'u8, 0x89'u8, 0x67'u8, 0x45'u8, 0x23'u8, 0x01'u8]
+  doAssert forwardInt.toBytesLE == reverseBytes
 
   doAssert 0x01'u8 == uint8.fromBytesBE([0x01'u8])
   doAssert 0x0123'u16 == uint16.fromBytesBE([0x01'u8, 0x23'u8])
@@ -21,6 +38,7 @@ template test() =
     [0x01'u8, 0x23'u8, 0x45'u8, 0x67'u8])
   doAssert 0x0123456789abcdef'u64 == uint64.fromBytesBE(
     [0x01'u8, 0x23'u8, 0x45'u8, 0x67'u8, 0x89'u8, 0xab'u8, 0xcd'u8, 0xef'u8])
+  doAssert forwardInt == uint.fromBytesBE(forwardBytes)
 
   doAssert 0x01'u8 == uint8.fromBytesLE([0x01'u8])
   doAssert 0x0123'u16 == uint16.fromBytesLE([0x23'u8, 0x01'u8])
@@ -28,6 +46,7 @@ template test() =
     [0x67'u8, 0x45'u8, 0x23'u8, 0x01'u8])
   doAssert 0x0123456789abcdef'u64 == uint64.fromBytesLE([
     0xef'u8, 0xcd'u8, 0xab'u8, 0x89'u8, 0x67'u8, 0x45'u8, 0x23'u8, 0x01'u8])
+  doAssert forwardInt == uint.fromBytesLE(reverseBytes)
 
   doAssert 0x01234567'u32.swapBytes() == 0x67452301
 


### PR DESCRIPTION
Otherwise, nbc can't (readily, without its own workarounds) switch to using `endians2` instead of its own code. bitseqs uses `uint`, so even though non-size-specified types might not prove ideal for serialization, it's still useful for endians2 to support it.