### PR TITLE
leb128 + bitops fixes

### DIFF
--- a/stew/leb128.nim
+++ b/stew/leb128.nim
@@ -1,8 +1,9 @@
-## Low-level little-endian base 128 variable length integer operators, as
+## Low-level little-endian base 128 variable length integer/byte converters, as
 ## described in https://en.wikipedia.org/wiki/LEB128 - up to 64 bits supported.
 ##
-## Used in formats like DWARF, WASM - unsigned variant identical to protobuf/go
-## varint.
+## Used in formats like DWARF, WASM - the encoding is fully compatible with
+## unsigned protobuf, go varint:s and can therefore directly be used for them -
+## signed varint:s can easily be implemented on top.
 ##
 ## This implementation contains low-level primitives suitable for building
 ## more easy-to-use API.
@@ -51,7 +52,7 @@ type
 template write7(next: untyped) =
   # write 7 bits of data
   if v > type(v)(127):
-    result.data[result.len] = cast[byte](v) or 0x80'u8
+    result.data[result.len] = cast[byte](v and type(v)(0xff)) or 0x80'u8
     result.len += 1
     v = v shr 7
     next
@@ -84,7 +85,7 @@ func toBytes*[I: SomeUnsignedInt](v: I, T: type Leb128): Leb128Buf[I] {.noinit.}
                     discard
 
   # high bit not set since v <= 127 at this point!
-  result.data[result.len] = cast[byte](v)
+  result.data[result.len] = cast[byte](v and type(v)(0xff))
   result.len += 1
 
 template read7(shift: untyped) =

--- a/stew/leb128.nim
+++ b/stew/leb128.nim
@@ -1,0 +1,156 @@
+## Low-level little-endian base 128 variable length integer operators, as
+## described in https://en.wikipedia.org/wiki/LEB128 - up to 64 bits supported.
+##
+## Used in formats like DWARF, WASM - unsigned variant identical to protobuf/go
+## varint.
+##
+## This implementation contains low-level primitives suitable for building
+## more easy-to-use API.
+##
+## Exception/Defect free as of nim 1.2.
+
+{.push raises: [].}
+
+import
+  stew/bitops2
+
+const
+  # Given the truncated logarithm of a 64-bit number, how many bytes do we need
+  # to encode it?
+  lengths = block:
+    var v: array[64, int8]
+    for i in 0..<64:
+      v[i] = int8((i + 7) div 7)
+    v
+
+type
+  Leb128* = object
+    ## Type used to mark leb128 encoding helpers
+
+# log2trunc by definition never returns values >64, thus we can remove checks
+{.push checks: off.}
+func len*(T: type Leb128, x: SomeUnsignedInt): int8 =
+  ## Returns number of bytes required to encode integer ``x`` as leb128.
+  if x == 0: 1 # Always at least one byte!
+  else: lengths[log2trunc(x)]
+{.pop.}
+
+func maxLen*(T: type Leb128, I: type): int8 =
+  ## The maximum number of bytes needed to encode any value of type I
+  Leb128.len(I.high)
+
+type
+  Leb128Buf*[T: SomeUnsignedInt] = object
+    data*: array[maxLen(Leb128, T), byte] # len(data) <= 10
+    len*: int8 # >= 1 when holding valid protobuf
+
+  Leb128Error* = enum
+    incomplete = "End marker not found in given stream"
+    overflow = "Value would overflow"
+
+template write7(next: untyped) =
+  # write 7 bits of data
+  if v > type(v)(127):
+    result.data[result.len] = cast[byte](v) or 0x80'u8
+    result.len += 1
+    v = v shr 7
+    next
+
+# LebBuf size corresponds to maximum size that the type will be encoded to, thus
+# there can be no out-of-bounds accesses here - likewise with the length
+# arithmetic
+{.push checks: off.}
+func toBytes*[I: SomeUnsignedInt](v: I, T: type Leb128): Leb128Buf[I] {.noinit.} =
+  ## Convert an unsigned integer to the smallest leb128 representation possible
+  ##
+  ## Example:
+  ## 15'u16.toBytes(Leb128)
+  var
+    v = v
+  result.len = 0
+
+  # A clever developer would write something clever for the unrolling -
+  # fortunately, we have clever compilers that remove the excess unrolls based
+  # on size!
+  write7(): # 7
+    write7(): # 14
+      write7(): # 21
+        write7(): # 28
+          write7(): # 35
+            write7(): # 42
+              write7(): # 49
+                write7(): # 56
+                  write7(): # 63
+                    discard
+
+  # high bit not set since v <= 127 at this point!
+  result.data[result.len] = cast[byte](v)
+  result.len += 1
+
+template read7(shift: untyped) =
+  # Read 7 bits of data and return iff these are the last 7 bits
+  if (shift div 7) >= xlen:
+    return (I(0), 0'i8)
+  let
+    b = x[shift div 7]
+    valb = b and 0x7f'u8 # byte without high bit
+    val = I(valb)
+    vals = val shl shift
+
+  when shift >= (sizeof(val) * 8 - 7):
+    if vals shr shift != val:
+      return (I(0), -cast[int8]((shift div 7) + 1))
+
+  res = res or vals
+  if b == valb: # High bit not set
+    return (res, cast[int8]((shift div 7) + 1))
+
+func fromBytes*(
+    I: type SomeUnsignedInt,
+    x: openArray[byte],
+    T: type Leb128): tuple[val: I, len: int8] {.noinit.} =
+  ## Parse a LEB128 byte sequence and return value and how many bytes were
+  ## parsed - if parsing fails, len <= 0 will be returned - 0 when there are not
+  ## enough bytes and -len on overflow, signalling how many bytes were parsed
+  let xlen = x.len()
+  var
+    res: I
+
+  read7(0)
+  read7(7)
+  read7(14)
+  read7(21)
+  read7(28)
+  read7(35)
+  read7(42)
+  read7(49)
+  read7(56)
+  read7(63)
+
+  (I(0), -11'i8)
+
+{.pop.}
+
+template toOpenArray*(v: Leb128Buf): openArray[byte] =
+  toOpenArray(v.data, 0, v.len - 1)
+
+template len*(v: Leb128Buf): int8 = v.len
+template `@`*(v: Leb128Buf): seq[byte] = @(v.toOpenArray())
+iterator items*(v: Leb128Buf): byte =
+  for i in 0..<v.len: yield v.data[i]
+
+template fromBytes*(
+    I: type SomeUnsignedInt,
+    x: Leb128Buf): tuple[val: I, len: int8] =
+  # x is not guaranteed to be valid, so we treat it like any other buffer!
+  I.fromBytes(x.toOpenArray(), Leb128)
+
+func scan*(
+    I: type SomeUnsignedInt,
+    x: openArray[byte],
+    T: type Leb128): int8 {.noinit.} =
+  ## Scan a buffer for a valid leb128-encoded value that at most fits in a
+  ## uint64, and report how many bytes it uses
+  # TODO this can be done efficiently with SSE
+  I.fromBytes(x, Leb128).len
+

--- a/stew/leb128.nim
+++ b/stew/leb128.nim
@@ -45,10 +45,6 @@ type
     data*: array[maxLen(Leb128, T), byte] # len(data) <= 10
     len*: int8 # >= 1 when holding valid protobuf
 
-  Leb128Error* = enum
-    incomplete = "End marker not found in given stream"
-    overflow = "Value would overflow"
-
 template write7(next: untyped) =
   # write 7 bits of data
   if v > type(v)(127):

--- a/stew/leb128.nim
+++ b/stew/leb128.nim
@@ -23,9 +23,12 @@
 ## decoding at the maximum length that a minimal encoder will produce. For
 ## example, the byte sequence `[byte 0x80, 0x80, 0x00]`, when decoded as a
 ## `uint64` is a valid encoding for `0` because the maximum length of a minimal
-## `uint64` encoding is 10 bytes - but because all minimal encodings
+## `uint64` encoding is 10 bytes - however, because all minimal encodings
 ## for `uint8` fit in 2 bytes, decoding the same byte sequence as `uint8` will
 ## yield an error return.
+##
+## To be strict about overlong encodings, compare the decoded number of bytes
+## with `Leb128.len(decoded_value)`.
 
 {.push raises: [].}
 

--- a/stew/varints.nim
+++ b/stew/varints.nim
@@ -17,6 +17,8 @@
 #   "common" way of encoding signed integers in protobuf is "zig-zag" which
 #   whose support is missing - above all, biasing towards one of the two signed
 #   integer formats is error-prone
+# * there is no detection of overlong sequences
+# * overflows in high bits of nibble are not detected
 
 import
   bitops2

--- a/stew/varints.nim
+++ b/stew/varints.nim
@@ -1,5 +1,23 @@
 ## This module implements Variable Integer `VARINT`.
 
+{.deprecated: "use leb128 or a higher level decoder".}
+
+# There are better variations on this module around:
+# * stew/leb128 implements the core varint encoding
+# * nim-protobuf-serialization and nim-libp2p contain higher-level protobuf
+#   varint encoding/decoding
+#
+# This module has a couple of problems as written:
+# * Name conflict with std/varints which implements a _different_ varint
+#   encoding (sqlite-style)
+# * the `Stream` interface in this file is underdefined (ie there's a hidden
+#   implicit dependency on nim-serialization - the stateful byte-by-byte
+#   decoder should likely be moved there instead
+# * The signed integer support is biased towards casting, whereas the most
+#   "common" way of encoding signed integers in protobuf is "zig-zag" which
+#   whose support is missing - above all, biasing towards one of the two signed
+#   integer formats is error-prone
+
 import
   bitops2
 

--- a/tests/test_leb128.nim
+++ b/tests/test_leb128.nim
@@ -83,11 +83,13 @@ suite "leb128":
 
   test "errors":
     check:
-      uint8.fromBytes([0x80'u8], Leb128).len == 0
-      uint8.fromBytes([0x80'u8, 0x80], Leb128).len == 0
+      uint8.fromBytes([0x80'u8], Leb128) == (0'u8, 0'i8)
+      uint8.fromBytes([0x80'u8, 0x80], Leb128) == (0'u8, 0'i8)
       uint8.fromBytes(toBytes(256'u16, Leb128).toOpenArray(), Leb128).len < 0
+      uint8.fromBytes([0x80'u8, 0x02], Leb128) == (0'u8, -2'i8) # 2 bytes consumed and overflow
+      uint8.fromBytes([0x80'u8, 0x02, 0x05], Leb128) == (0'u8, -2'i8) # 2 bytes consumed and overflow
       uint64.fromBytes([0xff'u8, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x02], Leb128).len < 0
-      uint64.fromBytes([0xff'u8, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff], Leb128).len == 0
+      uint64.fromBytes([0xff'u8, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff], Leb128) == (0'u64, 0'i8)
 
     check:
       uint8.scan([0x80'u8], Leb128) == 0

--- a/tests/test_leb128.nim
+++ b/tests/test_leb128.nim
@@ -1,0 +1,97 @@
+import
+  unittest, random,
+  ../stew/[byteutils, leb128, results]
+
+const edgeValues = {
+  0'u64                     : "00",
+  1'u64                     : "01",
+  (1'u64 shl 7) - 1'u64     : "7f",
+  (1'u64 shl 7)             : "8001",
+  (1'u64 shl 7) + 1'u64     : "8101",
+  (1'u64 shl 14) - 1'u64    : "ff7f",
+  (1'u64 shl 14)            : "808001",
+  (1'u64 shl 21) - 1'u64    : "ffff7f",
+  (1'u64 shl 21)            : "80808001",
+  (1'u64 shl 28) - 1'u64    : "ffffff7f",
+  (1'u64 shl 28)            : "8080808001",
+  (1'u64 shl 35) - 1'u64    : "ffffffff7f",
+  (1'u64 shl 35)            : "808080808001",
+  (1'u64 shl 42) - 1'u64    : "ffffffffff7f",
+  (1'u64 shl 42)            : "80808080808001",
+  (1'u64 shl 49) - 1'u64    : "ffffffffffff7f",
+  (1'u64 shl 49)            : "8080808080808001",
+  (1'u64 shl 56) - 1'u64    : "ffffffffffffff7f",
+  (1'u64 shl 56)            : "808080808080808001",
+  (1'u64 shl 63) - 1'u64    : "ffffffffffffffff7f",
+  (1'u64 shl 63)            : "80808080808080808001",
+  0xFFFF_FFFF_FFFF_FFFF'u64 : "ffffffffffffffffff01"
+}
+
+suite "leb128":
+  template roundtripTest(value: typed) =
+    let
+      leb {.inject.} = value.toBytes(Leb128)
+      roundtripVal = type(value).fromBytes(leb.toOpenArray(), Leb128)
+
+    check:
+      value == roundtripVal.val
+
+  test "Success edge cases test":
+    for pair in edgeValues:
+      let (value, hex) = pair
+      roundtripTest value
+      check:
+        toHex(leb.toOpenArray()) == hex
+
+  test "roundtrip random values":
+    for i in 0..10000:
+      # TODO nim 1.0 random casts limits to int, so anything bigger will crash
+      #      * sigh *
+      let
+        v1 = rand(0'u64 .. cast[uint64](int.high))
+      roundtripTest v1
+
+
+  test "lengths":
+    const lengths = {
+      0'u64                     : 1,
+      1'u64                     : 1,
+      (1'u64 shl 7) - 1'u64     : 1,
+      (1'u64 shl 7)             : 2,
+      (1'u64 shl 7) + 1'u64     : 2,
+      (1'u64 shl 14) - 1'u64    : 2,
+      (1'u64 shl 14)            : 3,
+      (1'u64 shl 21) - 1'u64    : 3,
+      (1'u64 shl 21)            : 4,
+      (1'u64 shl 28) - 1'u64    : 4,
+      (1'u64 shl 28)            : 5,
+      (1'u64 shl 35) - 1'u64    : 5,
+      (1'u64 shl 35)            : 6,
+      (1'u64 shl 42) - 1'u64    : 6,
+      (1'u64 shl 42)            : 7,
+      (1'u64 shl 49) - 1'u64    : 7,
+      (1'u64 shl 49)            : 8,
+      (1'u64 shl 56) - 1'u64    : 8,
+      (1'u64 shl 56)            : 9,
+      (1'u64 shl 63) - 1'u64    : 9,
+      (1'u64 shl 63)            : 10,
+      0xFFFF_FFFF_FFFF_FFFF'u64 : 10
+    }
+
+    for pair in lengths:
+      check: Leb128.len(pair[0]) == pair[1]
+
+  test "errors":
+    check:
+      uint8.fromBytes([0x80'u8], Leb128).len == 0
+      uint8.fromBytes([0x80'u8, 0x80], Leb128).len == 0
+      uint8.fromBytes(toBytes(256'u16, Leb128).toOpenArray(), Leb128).len < 0
+      uint64.fromBytes([0xff'u8, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x02], Leb128).len < 0
+      uint64.fromBytes([0xff'u8, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff], Leb128).len == 0
+
+    check:
+      uint8.scan([0x80'u8], Leb128) == 0
+      uint8.scan([0x80'u8, 0x80], Leb128) == 0
+      uint8.scan(toBytes(256'u16, Leb128).toOpenArray(), Leb128) < 0
+      uint64.scan([0xff'u8, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x02], Leb128) < 0
+      uint64.scan([0xff'u8, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff], Leb128) == 0

--- a/tests/test_leb128.nim
+++ b/tests/test_leb128.nim
@@ -44,14 +44,18 @@ suite "leb128":
         toHex(leb.toOpenArray()) == hex
 
   test "roundtrip random values":
-    for i in 0..10000:
-      # TODO nim 1.0 random casts limits to int, so anything bigger will crash
-      #      * sigh *
-      #      https://github.com/nim-lang/Nim/issues/16360
-      let
-        v1 = rand(0'u64 .. cast[uint64](int.high))
-      roundtripTest v1
-
+    template testSome(T: type) =
+      for i in 0..10000:
+        # TODO nim 1.0 random casts limits to int, so anything bigger will crash
+        #      * sigh *
+        #      https://github.com/nim-lang/Nim/issues/16360
+        let
+          v1 = rand(T(0) .. cast[T](int.high))
+        roundtripTest v1
+    testSome(uint8)
+    testSome(uint16)
+    testSome(uint32)
+    testSome(uint64)
 
   test "lengths":
     const lengths = {

--- a/tests/test_leb128.nim
+++ b/tests/test_leb128.nim
@@ -47,6 +47,7 @@ suite "leb128":
     for i in 0..10000:
       # TODO nim 1.0 random casts limits to int, so anything bigger will crash
       #      * sigh *
+      #      https://github.com/nim-lang/Nim/issues/16360
       let
         v1 = rand(0'u64 .. cast[uint64](int.high))
       roundtripTest v1


### PR DESCRIPTION
Leb128 is a variable-length encoding for unsigned integers that is used
in a number of contexts - in particular, wasm, dwarf and protobuf.

This is an optimized low-level implementation that unrolls the loop
reading/writing the buffer - it is suitable to use as base for a more
specific API - no memory allocations, no exceptions.

This PR also fixes bitops2 to not raise on certain `uint->int`
conversions, adapting `bitops2` to nim 1.0 conversion rules by using a cast
instead of raising on `uint->int` conversion