### PR TITLE
Allow comparing Result[void, E]

### DIFF
--- a/stew/results.nim
+++ b/stew/results.nim
@@ -442,11 +442,14 @@ template capture*[E: Exception](T: type, someExceptionExpr: ref E): Result[T, re
     ret = R.err(caught)
   ret
 
-func `==`*[T0, E0, T1, E1](lhs: Result[T0, E0], rhs: Result[T1, E1]): bool {.inline.} =
+func `==`*[T, E](lhs: Result[T, E], rhs: Result[T, E]): bool {.inline.} =
   if lhs.o != rhs.o:
     false
   elif lhs.o: # and rhs.o implied
-    lhs.v == rhs.v
+    when T is void:
+      true
+    else:
+      lhs.v == rhs.v
   else:
     lhs.e == rhs.e
 

--- a/tests/test_results.nim
+++ b/tests/test_results.nim
@@ -275,3 +275,8 @@ func cstringF(s: string): CSRes =
     doAssert false
 
 discard cstringF("test")
+
+# Compare void
+block:
+  var a, b: Result[void, bool]
+  discard a == b


### PR DESCRIPTION
This allow comparing `Result[void, E]` types.

Also simplify the signature

```Nim
func `==`*[T0, E0, T1, E1](lhs: Result[T0, E0], rhs: Result[T1, E1]): bool {.inline.} =
```

The case where `==` is defined for 2 different types is very rare, unused in our case and it's better to an explicit conversion anyway and people can use a converter otherwise.

This might even improve compilation time by being less taxing on the number of generics to keep track of.