### PR TITLE
fixes bug in base64 decoder when decoding byte sequence

### DIFF
--- a/stew/base64.nim
+++ b/stew/base64.nim
@@ -170,7 +170,7 @@ proc decode*[T: byte|char](btype: typedesc[Base64Types], instr: openarray[T],
   var inlen = len(instr)
   when (btype is Base64PadTypes):
     for i in countdown(inlen - 1, 0):
-      if instr[i] != '=':
+      if instr[i] != T('='):
         break
       dec(inlen)
 

--- a/tests/test_base64.nim
+++ b/tests/test_base64.nim
@@ -1,5 +1,5 @@
 import unittest
-import ../stew/base64
+import ../stew/[base64, byteutils]
 
 when defined(nimHasUsed): {.used.}
 
@@ -162,3 +162,11 @@ suite "BASE64 encoding test suite":
       decsize == 0
       Base64Url.decode("/+", decres, decsize) == Base64Status.Incorrect
       decsize == 0
+
+  test "Decode byte sequence":
+    let data = "Hello World".toBytes()
+    let base64 = Base64.encode(data).toBytes()
+    var decres = newSeq[byte](20)
+    var decsize = 0
+    check:
+      Base64.decode(base64, decres, decsize) == Base64Status.Success


### PR DESCRIPTION
the decoder accepts string or byte sequence but assume
the inner type is a char, now fixed