### PR TITLE
endians2: use copyMem instead of loop outside of vm

### DIFF
--- a/stew/arrayops.nim
+++ b/stew/arrayops.nim
@@ -46,13 +46,20 @@ func mnot*[N: static int; T](x: var array[N, T], y: array[N, T]) =
   eachElement(x, x, `not`)
 
 func copyFrom*[T](
-    v: var openArray[T], src: openArray[T]): Natural {.raises: [Defect].} =
+    v: var openArray[T], src: openArray[T]): Natural =
   ## Copy `src` contents into `v` - this is a permissive assignment where `src`
   ## may contain both fewer and more elements than `v`. Returns the number of
   ## elements copied which may be less than N when `src` is shorter than v
   let elems = min(v.len, src.len)
   assign(v.toOpenArray(0, elems - 1), src.toOpenArray(0, elems - 1))
   elems
+
+func initCopyFrom*[N: static[int], T](
+    A: type array[N, T], src: openArray[T]): A =
+  ## Copy `src` contents into an array - this is a permissive copy where `src`
+  ## may contain both fewer and more elements than `N`.
+  let elems = min(N, src.len)
+  assign(result.toOpenArray(0, elems - 1), src.toOpenArray(0, elems - 1))
 
 func initArrayWith*[N: static[int], T](value: T): array[N, T] {.noinit, inline.}=
   result.fill(value)

--- a/stew/endians2.nim
+++ b/stew/endians2.nim
@@ -142,11 +142,12 @@ func fromBytes*(
   ##      the length on both
   ##
   # compilers can usually prove this check is not needed and remove it
-  doAssert x.len >= sizeof(tmp), "Not enough bytes for endian conversion"
-
 
   const ts = sizeof(T) # Nim bug: can't use sizeof directly
   var tmp: array[ts, byte]
+
+  doAssert x.len >= sizeof(tmp), "Not enough bytes for endian conversion"
+
   when nimvm: # No copyMem in vm
     for i in 0..<tmp.len:
       tmp[i] = x[i]

--- a/stew/endians2.nim
+++ b/stew/endians2.nim
@@ -141,7 +141,9 @@ func fromBytes*(
   ##      endian, but less so for big endian - for now, it's easier to enforce
   ##      the length on both
   ##
+  # compilers can usually prove this check is not needed and remove it
   doAssert x.len >= sizeof(tmp), "Not enough bytes for endian conversion"
+
 
   const ts = sizeof(T) # Nim bug: can't use sizeof directly
   var tmp: array[ts, byte]

--- a/tests/test_arrayops.nim
+++ b/tests/test_arrayops.nim
@@ -24,3 +24,12 @@ suite "arrayops":
       (a or b) == [a[0] or b[0], a[1] or b[1]]
       (a xor b) == [a[0] xor b[0], a[1] xor b[1]]
       (not a) == [not a[0], not a[1]]
+
+  test "copyFrom":
+    let
+      a = [byte 4, 5]
+
+    check:
+      array[4, byte].initCopyFrom(a) == [byte 4, 5, 0, 0]
+      array[1, byte].initCopyFrom(a) == [byte 4]
+      array[2, byte].initCopyFrom(a) == [byte 4, 5]


### PR DESCRIPTION
Looking at generated assembly, it turns out the optimizer is not smart
enough to get rid of the loop - use `copyMem` instead.

At least the compiler is smart enough to constant-propagate runtime
endian direction, resolving the review comment.

Also clarify why a minimum length is enfored - it could perhaps be
revisited, but that would leave a slightly odd API.