### PR TITLE
byteutils: drop import of assign2 since arrayops imports/exports it

### DIFF
--- a/stew/byteutils.nim
+++ b/stew/byteutils.nim
@@ -11,7 +11,7 @@
 
 import
   std/[algorithm, typetraits],
-  ./assign2, ./arrayops
+  ./arrayops
 
 # backwards compat
 export arrayops.`&`, arrayops.initArrayWith, arrayops.`[]=`


### PR DESCRIPTION
Closes #99