### PR TITLE
results: `[]` for void

### DIFF
--- a/stew/results.nim
+++ b/stew/results.nim
@@ -714,10 +714,14 @@ func get*[T: not void, E](self: var Result[T, E]): var T {.inline.} =
   assertOk(self)
   self.v
 
-template `[]`*[T, E](self: Result[T, E]): T =
+template `[]`*[T: not void, E](self: Result[T, E]): T =
   ## Fetch value of result if set, or raise Defect
   ## Exception bridge mode: raise given Exception instead
   self.get()
+
+template `[]`*[E](self: Result[void, E]) =
+  ## Fetch value of result if set, or raise Defect
+  ## Exception bridge mode: raise given Exception instead
 
 template `[]`*[T: not void, E](self: var Result[T, E]): var T =
   ## Fetch value of result if set, or raise Defect

--- a/tests/test_results.nim
+++ b/tests/test_results.nim
@@ -241,6 +241,7 @@ block: # Result[void, E]
   vOk.get()
   vOk.unsafeGet()
   vOk.expect("should never fail")
+  vOk[]
 
   # Comparisons
   doAssert (vOk == vOk)


### PR DESCRIPTION
mostly for consistency.. but it's used in nim-eth tests