### PR TITLE
remove ptrops generic distance()

### DIFF
--- a/stew/ptrops.nim
+++ b/stew/ptrops.nim
@@ -1,5 +1,5 @@
 # stew
-# Copyright 2018-2019 Status Research & Development GmbH
+# Copyright 2018-2022 Status Research & Development GmbH
 # Licensed under either of
 #
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
@@ -46,9 +46,3 @@ template distance*(a, b: pointer): int =
 
   # We assume two's complement wrapping behaviour for `uint`
   cast[int](cast[uint](b) - cast[uint](a))
-
-template distance*[T](a, b: ptr T): int =
-  # Number of elements between a and b - undefined behavior when difference
-  # exceeds what can be represented in an int
-  {.checks: off.}
-  distance(cast[pointer](a), cast[pointer](b)) div sizeof(T)


### PR DESCRIPTION
Is there a reliable way to find out whether anyone in Status uses this? `nimbus-eth2` doesn't appear to. Haven't tried `nimbus-eth1` yet.

The whole thing is marked as deprecated, so might be safe to remove.

It gets rid of one of the `{.checks: off.}` (albeit, not the one directly responsible for https://github.com/status-im/nimbus-eth2/issues/3456, but lying in wait all the same) altogether. Better and less risky than fixing code no one might be using in a deprecated module.