### PR TITLE
don't disable checks in ptrops

### DIFF
--- a/stew/byteutils.nim
+++ b/stew/byteutils.nim
@@ -1,5 +1,5 @@
 # byteutils
-# Copyright (c) 2018 Status Research & Development GmbH
+# Copyright (c) 2018-2022 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at http://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at http://www.apache.org/licenses/LICENSE-2.0).
@@ -29,7 +29,7 @@ proc readHexChar*(c: char): byte
   of 'a'..'f': result = byte(ord(c) - ord('a') + 10)
   of 'A'..'F': result = byte(ord(c) - ord('A') + 10)
   else:
-    raise newException(ValueError, $c & " is not a hexademical character")
+    raise newException(ValueError, $c & " is not a hexadecimal character")
 
 template skip0xPrefix(hexStr: string): int =
   ## Returns the index of the first meaningful char in `hexStr` by skipping

--- a/stew/ptrops.nim
+++ b/stew/ptrops.nim
@@ -34,8 +34,8 @@ template offset*[T](p: ptr T, count: int): ptr T =
 
   # Actual behavior is wrapping, but this may be revised in the future to enable
   # better optimizations.
-  let bytes = count * sizeof(T)
-  cast[ptr T](offset(cast[pointer](p), bytes))
+  let bytes = cast[uint](count) * uint(sizeof(T))
+  cast[ptr T](offset(cast[pointer](p), cast[int](bytes)))
 
 template distance*(a, b: pointer): int =
   ## Number of bytes between a and b - undefined behavior when difference

--- a/stew/ptrops.nim
+++ b/stew/ptrops.nim
@@ -34,14 +34,8 @@ template offset*[T](p: ptr T, count: int): ptr T =
 
   # Actual behavior is wrapping, but this may be revised in the future to enable
   # better optimizations.
-
-  # We turn off checking here - too large counts is UB
-  {.push checks: off.}
-  let
-    bytes = count * sizeof(T)
-    res = cast[ptr T](offset(cast[pointer](p), bytes))
-  {.pop.}
-  res
+  let bytes = count * sizeof(T)
+  cast[ptr T](offset(cast[pointer](p), bytes))
 
 template distance*(a, b: pointer): int =
   ## Number of bytes between a and b - undefined behavior when difference
@@ -53,7 +47,4 @@ template distance*(a, b: pointer): int =
 template distance*[T](a, b: ptr T): int =
   # Number of elements between a and b - undefined behavior when difference
   # exceeds what can be represented in an int
-  {.push checks: off.}
-  let res = distance(cast[pointer](a), cast[pointer](b)) div sizeof(T)
-  {.pop.}
-  res
+  distance(cast[pointer](a), cast[pointer](b)) div sizeof(T)


### PR DESCRIPTION
The net effect of this change is:
```diff
--- ptrops_orig.nim.c	2022-03-16 17:56:35.054520879 +0100
+++ ptrops.nim.c	2022-03-16 17:56:55.126262722 +0100
@@ -21,6 +21,9 @@
 #define nimln_(x, y)
 N_LIB_PRIVATE N_NIMCALL(void, test_offset__GUeAIxBAJ79bdeFn6EpeyzA)(void);
 N_LIB_PRIVATE N_NIMCALL(void, test_distance__GUeAIxBAJ79bdeFn6EpeyzA_2)(void);
+N_LIB_PRIVATE N_NOINLINE(void, raiseDivByZero)(void);
+static N_INLINE(NIM_BOOL, nimDivInt)(NI a, NI b, NI* res);
+N_LIB_PRIVATE N_NOINLINE(void, raiseOverflow)(void);
 static N_INLINE(void, initStackBottomWith)(void* locals);
 N_LIB_PRIVATE N_NOINLINE(void, nimGC_setStackBottom)(void* theStackBottom);
 N_LIB_PRIVATE N_NIMCALL(void, systemDatInit000)(void);
@@ -36,17 +39,41 @@
 	bytesX60gensym4618021_ = ((NI) 24);
 	c = ((NI*) (((void*) ((NU)((NU64)(((NU) (ptrdiff_t) (((void*) (b))))) + (NU64)(((NU) (bytesX60gensym4618021_))))))));
 }
+static N_INLINE(NIM_BOOL, nimDivInt)(NI a, NI b, NI* res) {
+	NIM_BOOL result;
+	result = (NIM_BOOL)0;
+	{
+		NIM_BOOL T3_;
+		T3_ = (NIM_BOOL)0;
+		T3_ = (a == ((NI) (IL64(-9223372036854775807) - IL64(1))));
+		if (!(T3_)) goto LA4_;
+		T3_ = (b == ((NI) -1));
+		LA4_: ;
+		if (!T3_) goto LA5_;
+		result = NIM_TRUE;
+	}
+	goto LA1_;
+	LA5_: ;
+	{
+		(*res) = (NI)(a / b);
+	}
+	LA1_: ;
+	return result;
+}
 N_LIB_PRIVATE N_NIMCALL(void, test_distance__GUeAIxBAJ79bdeFn6EpeyzA_2)(void) {
 	NI a;
 	NI b;
 	NI* c;
 	NI* d;
 	NI e;
+	NI TM__R8RUzYq41iOx0I9bZH5Nyrw_2;
 	a = ((NI) 3);
 	b = ((NI) 4);
 	c = (&a);
 	d = (&b);
-	e = (NI)(((NI) ((NU)((NU64)(((NU) (ptrdiff_t) (((void*) (d))))) - (NU64)(((NU) (ptrdiff_t) (((void*) (c)))))))) / ((NI) 8));
+	if (((NI) 8) == 0){ raiseDivByZero(); }
+	if (nimDivInt(((NI) ((NU)((NU64)(((NU) (ptrdiff_t) (((void*) (d))))) - (NU64)(((NU) (ptrdiff_t) (((void*) (c)))))))), ((NI) 8), &TM__R8RUzYq41iOx0I9bZH5Nyrw_2)) { raiseOverflow(); };
+	e = (NI)(TM__R8RUzYq41iOx0I9bZH5Nyrw_2);
 }
 static N_INLINE(void, initStackBottomWith)(void* locals) {
 	nimGC_setStackBottom(locals);

```
That is, it's checking for `low(SomeSignedInt) div -1` and that's it. That will never arise in the context of either `offset()` or `distance()`.

When compiling a test harness:
```nim
import "."/ptrops
#import "."/ptrops_orig

proc test_offset() =
  var a = 3
  var b = unsafeAddr a
  var c = offset(b, 3)

proc test_distance() =
  var a = 3
  var b = 4
  var c = unsafeAddr a
  var d = unsafeAddr b
  var e = distance(c, d)

test_offset()
test_distance()
```
where `ptrops_orig` is the one used by `nimbus-eth2` `unstable` currently (not `master` here) and `ptrops` is what this PR proposes.

Tested in both Nim 1.2 and Nim 1.6. The `offset()` template which disabled `checks` never generated any C code which might trigger such checks in any combination of (Nim 1.2, Nim 1.6) and (`-d:debug` and `-d:release`) regardless so removing `offset()`'s pragma is a no-op.
[ptrops.nim.c.txt](https://github.com/status-im/nim-stew/files/8266714/ptrops.nim.c.txt)
[ptrops_orig.nim.c.txt](https://github.com/status-im/nim-stew/files/8266716/ptrops_orig.nim.c.txt)

`distance()` is more interesting because one can see that it does, in fact, generate more code. Specifically, it generates two checks:
```c
if (((NI) 8) == 0){ raiseDivByZero(); }
```
and
```c
if (nimDivInt(((NI) ((NU)((NU64)(((NU) (ptrdiff_t) (((void*) (d))))) - (NU64)(((NU) (ptrdiff_t) (((void*) (c)))))))), ((NI) 8), &TM__R8RUzYq41iOx0I9bZH5Nyrw_2)) { raiseOverflow(); };
```

It does not actually need to do either of these things, because while 8 comes from the `sizeof(T)` here and might be something else, it will always be a non-negative, compile-time constant. A Nim issue on this point: https://github.com/nim-lang/Nim/issues/19615

At least any reasonable C compiler should, even at low optimization levels, simply remove the
```c
if (((NI) 8) == 0){ raiseDivByZero(); }
```

That's the good part: both pieces of code here are, in fact, safe.

Pending a resolution of that issue, I investigated three main approaches:
(a) status quo in `nimbus-eth2`, i.e. checks off;
(b) (a) but checks not disabled; and
(c) a workaround using unsigned integer division to simulate signed integer division, avoiding this overflow check being generated.

I benchmarked all three using a microbenchmark:
```nim
{.checks: off.}
template unsignedIntType[T: SomeSignedInt](): untyped =
  when T is int8:
    type U = uint8
  elif T is int16:
    type U = uint16
  elif T is int32:
    type U = uint32
  elif T is int64:
    type U = uint64
  elif T is int:
    type U = uint
  else:
    static: doAssert false
  static: doAssert sizeof(T) == sizeof(U)

  U

template signedUnsignedIntDiv[T: SomeSignedInt](x: T, y: SomeUnsignedInt): T =
  type U = unsignedIntType[T]()
  let mask = cast[U](x shr (sizeof(T) * 8 - 1))
  template maybeNegate(n: T): T = cast[T]((cast[U](n) xor mask) - mask)
  maybeNegate(cast[T](cast[U](maybeNegate[T](x)) div y))

for i in -4000000000 .. 4000000001:
  # Also checked with variable j, but the actual use case involves compile-time
  # known j.
  const j = 8'u64
  let x = signedUnsignedIntDiv(i, j)
  let y = i div cast[int64](j)
  doAssert x == y
```
Enabling and disabling `doAssert`, `let x`, and `let y` as needed. I found no measurable difference in speed, but if someone else can, that'd be interesting. Otherwise, my inclination is to simply remove the `{.checks: off.}` pragmas entirely.