### PR TITLE
Revert "Add tests for recordFields being used with empty objects"

### DIFF
--- a/stew/shims/macros.nim
+++ b/stew/shims/macros.nim
@@ -76,13 +76,9 @@ macro isTuple*(T: type): untyped =
 
 proc skipRef*(T: NimNode): NimNode =
   result = T
-  if T.kind == nnkBracketExpr and eqIdent(T[0], "ref"):
-    result = T[1]
-
-proc skipPtr*(T: NimNode): NimNode =
-  result = T
-  if T.kind == nnkBracketExpr and eqIdent(T[0], "ptr"):
-    result = T[1]
+  if T.kind == nnkBracketExpr:
+    if eqIdent(T[0], bindSym"ref"):
+      result = T[1]
 
 template readPragma*(field: FieldDescription, pragmaName: static string): NimNode =
   let p = findPragma(field.pragmas, bindSym(pragmaName))

--- a/tests/test_macros.nim
+++ b/tests/test_macros.nim
@@ -36,14 +36,10 @@ type
   DerivedFromRefType = ref object of DerivedType
     anotherDerivedField: string
 
-  EmptyObject = object
-  EmptyRefObject = ref object
-  EmptyPtrObject = ptr object
-
 macro getFieldsLists(T: type): untyped =
   result = newTree(nnkBracket)
 
-  var resolvedType = skipPtr skipRef getType(T)[1]
+  var resolvedType = skipRef getType(T)[1]
   doAssert resolvedType.kind == nnkSym
   var objectType = getImpl(resolvedType)
   doAssert objectType.kind == nnkTypeDef
@@ -59,10 +55,6 @@ static:
     "derivedField",
     "anotherDerivedField"
   ]
-
-  doAssert getFieldsLists(EmptyObject).len == 0
-  doAssert getFieldsLists(EmptyRefObject).len == 0
-  doAssert getFieldsLists(EmptyPtrObject).len == 0
 
 let myType = MyType[string](myField: "test", myGeneric: "test", kind: true, first: "test")
 


### PR DESCRIPTION
This reverts commit b87fd80b0f1a4c3c3961e61fbea177ded22b34e0.

The tests are broken for nim-1.2 - this reverts them pending a PR with an actual fix (to prevent build breakage)