### PR TITLE
Add enum utilities and add enum with holes support

### DIFF
--- a/stew/objects.nim
+++ b/stew/objects.nim
@@ -1,5 +1,6 @@
 import
-  macros
+  macros,
+  sequtils
 
 template init*(lvalue: var auto) =
   mixin init
@@ -67,26 +68,26 @@ proc baseType*(obj: RootObj): cstring =
 proc baseType*(obj: ref RootObj): cstring =
   obj[].baseType
 
-when false:
-  # TODO: Implementing this doesn't seem possible at the moment.
-  #
-  # When given enum like:
-  #
-  # type WithoutHoles2 = enum
-  #   A2 = 2, B2 = 3, C2 = 4
-  #
-  # ...the code below will print:
-  #
-  #  EnumTy
-  #    Empty
-  #    Sym "A2"
-  #    Sym "B2"
-  #    Sym "C2"
-  #
-  macro hasHoles*(T: type[enum]): bool =
-    let t = getType(T)[1]
-    echo t.treeRepr
-    return newLit(true)
+macro enumRangeOrd*(a: typed): untyped =
+  ## This macro returns an array with all the ordinal values of an enum
+  let
+    values = a.getType[1][1..^1]
+    valuesOrded = values.mapIt(newCall("ord", it))
+  newNimNode(nnkBracket).add(valuesOrded)
+
+proc contains*(e: type[enum], v: SomeInteger): bool =
+  v in enumRangeOrd(e)
+
+macro hasHoles*(T: type[enum]): bool =
+  # As an enum is always sorted, just substract the first and the last ordinal value
+  # and compare the result to the number of element in it will do the trick.
+  let
+    typ = T.getType[1]
+    s = typ[1]
+    e = typ[^1]
+    len = typ.len - 1
+
+  quote: `e`.ord - `s`.ord == `len`
 
 func checkedEnumAssign*[E: enum, I: SomeInteger](res: var E, value: I): bool =
   ## This function can be used to safely assign a tainted integer value (coming
@@ -94,14 +95,7 @@ func checkedEnumAssign*[E: enum, I: SomeInteger](res: var E, value: I): bool =
   ## if the integer value is within the acceped values of the enum and `false`
   ## otherwise.
 
-  # TODO: Enums with holes are not supported yet
-  # static: doAssert(not hasHoles(E))
-
-  when I is SomeSignedInt or low(E).int > 0:
-    if value < I(low(E)):
-      return false
-
-  if value > I(high(E)):
+  if value notin E:
     return false
 
   res = E value
@@ -113,4 +107,3 @@ func isZeroMemory*[T](x: T): bool =
     if b != 0:
       return false
   return true
-

--- a/stew/objects.nim
+++ b/stew/objects.nim
@@ -75,22 +75,18 @@ macro enumRangeOrd*(a: type[enum]): untyped =
     valuesOrded = values.mapIt(newCall("ord", it))
   newNimNode(nnkCurly).add(valuesOrded)
 
+macro hasHoles*(T: type[enum]): bool =
+  # As an enum is always sorted, just substract the first and the last ordinal value
+  # and compare the result to the number of element in it will do the trick.
+  let len = T.getType[1].len - 2
+
+  quote: `T`.high.ord - `T`.low.ord != `len`
+
 proc contains*(e: type[enum], v: SomeInteger): bool =
   when e.hasHoles():
     v in enumRangeOrd(e)
   else:
-    v in e.low.ord .. e.high.ord
-
-macro hasHoles*(T: type[enum]): bool =
-  # As an enum is always sorted, just substract the first and the last ordinal value
-  # and compare the result to the number of element in it will do the trick.
-  let
-    typ = T.getType[1]
-    s = typ[1]
-    e = typ[^1]
-    len = typ.len - 2
-
-  quote: `e`.ord - `s`.ord != `len`
+    v.int in e.low.ord .. e.high.ord
 
 func checkedEnumAssign*[E: enum, I: SomeInteger](res: var E, value: I): bool =
   ## This function can be used to safely assign a tainted integer value (coming

--- a/stew/objects.nim
+++ b/stew/objects.nim
@@ -68,7 +68,7 @@ proc baseType*(obj: RootObj): cstring =
 proc baseType*(obj: ref RootObj): cstring =
   obj[].baseType
 
-macro enumRangeOrd*(a: typed): untyped =
+macro enumRangeOrd*(a: type[enum]): untyped =
   ## This macro returns an array with all the ordinal values of an enum
   let
     values = a.getType[1][1..^1]

--- a/stew/objects.nim
+++ b/stew/objects.nim
@@ -73,10 +73,13 @@ macro enumRangeOrd*(a: type[enum]): untyped =
   let
     values = a.getType[1][1..^1]
     valuesOrded = values.mapIt(newCall("ord", it))
-  newNimNode(nnkBracket).add(valuesOrded)
+  newNimNode(nnkCurly).add(valuesOrded)
 
 proc contains*(e: type[enum], v: SomeInteger): bool =
-  v in enumRangeOrd(e)
+  when e.hasHoles():
+    v in enumRangeOrd(e)
+  else:
+    v in e.low.ord .. e.high.ord
 
 macro hasHoles*(T: type[enum]): bool =
   # As an enum is always sorted, just substract the first and the last ordinal value
@@ -85,9 +88,9 @@ macro hasHoles*(T: type[enum]): bool =
     typ = T.getType[1]
     s = typ[1]
     e = typ[^1]
-    len = typ.len - 1
+    len = typ.len - 2
 
-  quote: `e`.ord - `s`.ord == `len`
+  quote: `e`.ord - `s`.ord != `len`
 
 func checkedEnumAssign*[E: enum, I: SomeInteger](res: var E, value: I): bool =
   ## This function can be used to safely assign a tainted integer value (coming

--- a/stew/objects.nim
+++ b/stew/objects.nim
@@ -68,11 +68,11 @@ proc baseType*(obj: RootObj): cstring =
 proc baseType*(obj: ref RootObj): cstring =
   obj[].baseType
 
-macro enumRangeOrd*(a: type[enum]): untyped =
+macro enumRangeInt64*(a: type[enum]): untyped =
   ## This macro returns an array with all the ordinal values of an enum
   let
     values = a.getType[1][1..^1]
-    valuesOrded = values.mapIt(newCall("ord", it))
+    valuesOrded = values.mapIt(newCall("int64", it))
   newNimNode(nnkBracket).add(valuesOrded)
 
 macro hasHoles*(T: type[enum]): bool =
@@ -87,7 +87,7 @@ proc contains*[I: SomeInteger](e: type[enum], v: I): bool =
     if v > int.high.uint64:
       return false
   when e.hasHoles():
-    v.int64 in enumRangeOrd(e).mapIt(it.int64)
+    v.int64 in enumRangeInt64(e)
   else:
     v.int64 in e.low.int64 .. e.high.int64
 

--- a/tests/test_objects.nim
+++ b/tests/test_objects.nim
@@ -70,7 +70,7 @@ suite "Objects":
       T6 is DistinctBar
       T6 isnot Bar
 
-  test "enumRangeOrd":
+  test "enumRangeInt64":
     type
       WithoutHoles = enum
         A1, A2, A3
@@ -80,9 +80,9 @@ suite "Objects":
         C1 = 1, C2 = 3, C3 = 5
 
     check:
-      enumRangeOrd(WithoutHoles) == [ 0, 1, 2 ]
-      enumRangeOrd(WithoutHoles2) == [ 4, 5, 6 ]
-      enumRangeOrd(WithHoles) == [ 1, 3, 5 ]
+      enumRangeInt64(WithoutHoles) == [ 0'i64, 1, 2 ]
+      enumRangeInt64(WithoutHoles2) == [ 4'i64, 5, 6 ]
+      enumRangeInt64(WithHoles) == [ 1'i64, 3, 5 ]
 
 
   test "contains":

--- a/tests/test_objects.nim
+++ b/tests/test_objects.nim
@@ -93,6 +93,8 @@ suite "Objects":
         B1 = 4, B2 = 5, B3 = 6
       WithHoles = enum
         C1 = 1, C2 = 3, C3 = 5
+      WithoutHoles3 = enum
+        D1 = -1
 
     check:
       1 in WithoutHoles
@@ -103,6 +105,8 @@ suite "Objects":
       2 notin WithHoles
       6 notin WithHoles
       5 in WithHoles
+      1.byte in WithoutHoles
+      4294967295'u32 notin WithoutHoles3
 
   test "hasHoles":
     type

--- a/tests/test_objects.nim
+++ b/tests/test_objects.nim
@@ -80,9 +80,9 @@ suite "Objects":
         C1 = 1, C2 = 3, C3 = 5
 
     check:
-      enumRangeOrd(WithoutHoles) == [ 0, 1, 2 ]
-      enumRangeOrd(WithoutHoles2) == [ 4, 5, 6 ]
-      enumRangeOrd(WithHoles) == [ 1, 3, 5 ]
+      enumRangeOrd(WithoutHoles) == { 0, 1, 2 }
+      enumRangeOrd(WithoutHoles2) == { 4, 5, 6 }
+      enumRangeOrd(WithHoles) == { 1, 3, 5 }
 
 
   test "contains":
@@ -101,10 +101,14 @@ suite "Objects":
       5 in WithoutHoles2
       1 in WithHoles
       2 notin WithHoles
+      6 notin WithHoles
       5 in WithHoles
 
   test "hasHoles":
     type
+      EnumWithOneValue = enum
+        A0
+
       WithoutHoles = enum
         A1, B1, C1
 
@@ -114,10 +118,15 @@ suite "Objects":
       WithHoles = enum
         A3, B3 = 2, C3
 
+      WithBigHoles = enum
+        A4 = 0, B4 = 2000, C4 = 4000
+
     check:
-      hasHoles(WithoutHoles2) == false
+      hasHoles(EnumWithOneValue) == false
       hasHoles(WithoutHoles) == false
+      hasHoles(WithoutHoles2) == false
       hasHoles(WithHoles) == true
+      hasHoles(WithBigHoles) == true
 
   test "checkedEnumAssign":
     type

--- a/tests/test_objects.nim
+++ b/tests/test_objects.nim
@@ -70,23 +70,54 @@ suite "Objects":
       T6 is DistinctBar
       T6 isnot Bar
 
-  when false:
-    # TODO: Not possible yet (see objects.nim)
-    test "hasHoles":
-      type
-        WithoutHoles = enum
-          A1, B1, C1
+  test "enumRangeOrd":
+    type
+      WithoutHoles = enum
+        A1, A2, A3
+      WithoutHoles2 = enum
+        B1 = 4, B2 = 5, B3 = 6
+      WithHoles = enum
+        C1 = 1, C2 = 3, C3 = 5
 
-        WithoutHoles2 = enum
-          A2 = 2, B2 = 3, C2 = 4
+    check:
+      enumRangeOrd(WithoutHoles) == [ 0, 1, 2 ]
+      enumRangeOrd(WithoutHoles2) == [ 4, 5, 6 ]
+      enumRangeOrd(WithHoles) == [ 1, 3, 5 ]
 
-        WithHoles = enum
-          A3, B3 = 2, C3
 
-      check:
-        hasHoles(WithoutHoles2) == false
-        hasHoles(WithoutHoles) == false
-        hasHoles(WithHoles) == true
+  test "contains":
+    type
+      WithoutHoles = enum
+        A1, A2, A3
+      WithoutHoles2 = enum
+        B1 = 4, B2 = 5, B3 = 6
+      WithHoles = enum
+        C1 = 1, C2 = 3, C3 = 5
+
+    check:
+      1 in WithoutHoles
+      5 notin WithoutHoles
+      1 notin WithoutHoles2
+      5 in WithoutHoles2
+      1 in WithHoles
+      2 notin WithHoles
+      5 in WithHoles
+
+  test "hasHoles":
+    type
+      WithoutHoles = enum
+        A1, B1, C1
+
+      WithoutHoles2 = enum
+        A2 = 2, B2 = 3, C2 = 4
+
+      WithHoles = enum
+        A3, B3 = 2, C3
+
+    check:
+      hasHoles(WithoutHoles2) == false
+      hasHoles(WithoutHoles) == false
+      hasHoles(WithHoles) == true
 
   test "checkedEnumAssign":
     type
@@ -96,41 +127,40 @@ suite "Objects":
       AnotherEnum = enum
         A2 = 2, B2, C2
 
+      EnumWithHoles = enum
+        A3, B3 = 3, C3
     var
       e1 = A1
       e2 = A2
+      e3 = A3
 
     check:
       checkedEnumAssign(e1, 2)
       e1 == C1
-
-    check:
       not checkedEnumAssign(e1, 5)
       e1 == C1
-
-    check:
       checkedEnumAssign(e1, 0)
       e1 == A1
-
-    check:
       not checkedEnumAssign(e1, -1)
       e1 == A1
 
-    check:
       checkedEnumAssign(e2, 2)
       e2 == A2
-
-    check:
       not checkedEnumAssign(e2, 5)
       e2 == A2
-
-    check:
       checkedEnumAssign(e2, 4)
       e2 == C2
-
-    check:
       not checkedEnumAssign(e2, 1)
       e2 == C2
+
+      checkedEnumAssign(e3, 4)
+      e3 == C3
+      not checkedEnumAssign(e3, 1)
+      e3 == C3
+      checkedEnumAssign(e3, 0)
+      e3 == A3
+      not checkedEnumAssign(e3, -1)
+      e3 == A3
 
   test "isZeroMemory":
     type

--- a/tests/test_objects.nim
+++ b/tests/test_objects.nim
@@ -80,9 +80,9 @@ suite "Objects":
         C1 = 1, C2 = 3, C3 = 5
 
     check:
-      enumRangeOrd(WithoutHoles) == { 0, 1, 2 }
-      enumRangeOrd(WithoutHoles2) == { 4, 5, 6 }
-      enumRangeOrd(WithHoles) == { 1, 3, 5 }
+      enumRangeOrd(WithoutHoles) == [ 0, 1, 2 ]
+      enumRangeOrd(WithoutHoles2) == [ 4, 5, 6 ]
+      enumRangeOrd(WithHoles) == [ 1, 3, 5 ]
 
 
   test "contains":
@@ -94,7 +94,9 @@ suite "Objects":
       WithHoles = enum
         C1 = 1, C2 = 3, C3 = 5
       WithoutHoles3 = enum
-        D1 = -1
+        D1 = -1, D2 = 0, D3 = 1
+      WithHoles2 = enum
+        E1 = -5, E2 = 0, E3 = 5
 
     check:
       1 in WithoutHoles
@@ -107,6 +109,18 @@ suite "Objects":
       5 in WithHoles
       1.byte in WithoutHoles
       4294967295'u32 notin WithoutHoles3
+      -1.int8 in WithoutHoles3
+      -4.int16 notin WithoutHoles3
+      -5.int16 in WithHoles2
+      5.uint64 in WithHoles2
+      -12.int8 notin WithHoles2
+      int64.high notin WithoutHoles
+      int64.high notin WithHoles
+      int64.low notin WithoutHoles
+      int64.low notin WithHoles
+      int64.high.uint64 * 2 notin WithoutHoles
+      int64.high.uint64 * 2 notin WithHoles
+
 
   test "hasHoles":
     type


### PR DESCRIPTION
Add one macro and one procedure:
- macro enumRangeOrd(e: type[enum]): untyped
Creates an array with all the ordinal value of an enum (sorted by default from what I saw)
```nim
type
  Test = enum
    A1 = 1, B1 = 2, C1 = 3
  TestWithHoles = enum
    A2 = 1, B2 = 3, C2 = 5
assert(enumRangeOrd(Test) == [ 1, 2, 3 ])
assert(enumRangeOrd(TestWithHoles) == [ 1, 3, 5 ])
```
- proc contains(e: type[enum], v: SomeInteger): bool
With the macro described above, it checks if an integer is in the enum, in order to use someInt in / notin RandomEnum

In addition to that, I use those two macro/proc to implement the hole management in the macro hasHoles and the proc checkEnumAssign