### PR TITLE
Splitting `all_tests` wrapper

### DIFF
--- a/stew.nimble
+++ b/stew.nimble
@@ -19,8 +19,14 @@ task test, "Run all tests":
   test "--threads:off", "tests/all_tests"
   test "--threads:on -d:nimTypeNames", "tests/all_tests"
   test "--threads:on -d:noIntrinsicsBitOpts -d:noIntrinsicsEndians", "tests/all_tests"
+  test "--threads:off", "tests/all_tests2"
+  test "--threads:on -d:nimTypeNames", "tests/all_tests2"
+  test "--threads:on -d:noIntrinsicsBitOpts -d:noIntrinsicsEndians", "tests/all_tests2"
 
 task testvcc, "Run all tests with vcc compiler":
   test "--cc:vcc --threads:off", "tests/all_tests"
   test "--cc:vcc --threads:on -d:nimTypeNames", "tests/all_tests"
   test "--cc:vcc --threads:on -d:noIntrinsicsBitOpts -d:noIntrinsicsEndians", "tests/all_tests"
+  test "--cc:vcc --threads:off", "tests/all_tests2"
+  test "--cc:vcc --threads:on -d:nimTypeNames", "tests/all_tests2"
+  test "--cc:vcc --threads:on -d:noIntrinsicsBitOpts -d:noIntrinsicsEndians", "tests/all_tests2"

--- a/tests/all_tests2.nim
+++ b/tests/all_tests2.nim
@@ -7,35 +7,9 @@
 #
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
-import
-  ranges/all,
-  test_assign2,
-  test_arrayops,
-  test_base10,
-  test_base32,
-  test_base58,
-  test_base64,
-  test_bitops2,
-  test_bitseqs,
-  test_byteutils,
-  test_ctops,
-  test_endians2,
-  test_io2,
-  test_macros,
-  test_objects,
-  test_ptrops,
-  test_sequtils2,
-  test_sets,
-  test_templateutils,
-  test_results,
-  test_varints,
-  test_winacl
-
 # Running some unit tests in a separate file in order to mitigate global
 # symbols overflow on Github ci when compiling with nim version <= 1.2
 when 3 <= NimVersion.len and NimVersion[0..2] == "1.2":
-  discard
-else:
   import
     all_tests_ex
 

--- a/tests/all_tests_ex.nim
+++ b/tests/all_tests_ex.nim
@@ -1,0 +1,19 @@
+# stew
+# Copyright 2018-2019 Status Research & Development GmbH
+# Licensed under either of
+#
+#  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
+#  * MIT license ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)
+#
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+# Running some unit tests in a separate file in order to mitigate global
+# symbols overflow on Github ci when compiling with nim version <= 1.2.
+#
+# This file is simply a contiinuation of `all_tests`
+import
+  test_keyed_queue,
+  test_sorted_set,
+  test_interval_set
+
+# End


### PR DESCRIPTION
Running some unit tests in a separate file attempts to mitigate the global symbols overflow on Github ci when compiling with nim
  version <= 1.2.