### PR TITLE
Migrate to `unittest2`

### DIFF
--- a/stew.nimble
+++ b/stew.nimble
@@ -7,7 +7,8 @@ description   = "Backports, standard library candidates and small utilities that
 license       = "Apache License 2.0"
 skipDirs      = @["tests"]
 
-requires "nim >= 1.2.0"
+requires "nim >= 1.2.0",
+         "unittest2"
 
 ### Helper functions
 proc test(args, path: string) =

--- a/tests/ranges/tbitranges.nim
+++ b/tests/ranges/tbitranges.nim
@@ -1,5 +1,5 @@
 import
-  random, unittest,
+  random, unittest2,
   ../../stew/ranges/bitranges, ../../stew/bitseqs
 
 proc randomBytes(n: int): seq[byte] =

--- a/tests/ranges/tstackarrays.nim
+++ b/tests/ranges/tstackarrays.nim
@@ -1,5 +1,5 @@
 import
-  unittest, math,
+  unittest2, math,
   ../../stew/ptrops,
   ../../stew/ranges/[stackarrays]
 

--- a/tests/ranges/ttypedranges.nim
+++ b/tests/ranges/ttypedranges.nim
@@ -1,5 +1,5 @@
 import
-  unittest, sets,
+  unittest2, sets,
   ../../stew/ranges/[typedranges, ptr_arith]
 
 suite "Typed ranges":

--- a/tests/test_arrayops.nim
+++ b/tests/test_arrayops.nim
@@ -10,7 +10,7 @@
 {.used.}
 
 import
-  std/unittest,
+  unittest2,
   ../stew/arrayops
 
 suite "arrayops":

--- a/tests/test_assign2.nim
+++ b/tests/test_assign2.nim
@@ -1,5 +1,5 @@
 import
-  std/unittest,
+  unittest2,
   ../stew/assign2
 
 suite "assign2":

--- a/tests/test_base10.nim
+++ b/tests/test_base10.nim
@@ -1,4 +1,4 @@
-import unittest
+import unittest2
 import ../stew/base10
 
 when defined(nimHasUsed): {.used.}

--- a/tests/test_base32.nim
+++ b/tests/test_base32.nim
@@ -1,4 +1,4 @@
-import unittest
+import unittest2
 import ../stew/base32
 
 when defined(nimHasUsed): {.used.}

--- a/tests/test_base58.nim
+++ b/tests/test_base58.nim
@@ -1,4 +1,4 @@
-import unittest
+import unittest2
 import ../stew/base58
 
 when defined(nimHasUsed): {.used.}

--- a/tests/test_base64.nim
+++ b/tests/test_base64.nim
@@ -1,4 +1,4 @@
-import unittest
+import unittest2
 import ../stew/[base64, byteutils]
 
 when defined(nimHasUsed): {.used.}

--- a/tests/test_bitops2.nim
+++ b/tests/test_bitops2.nim
@@ -1,4 +1,4 @@
-import unittest
+import unittest2
 
 import ../stew/bitops2
 

--- a/tests/test_bitseqs.nim
+++ b/tests/test_bitseqs.nim
@@ -1,5 +1,5 @@
 import
-  unittest, strformat,
+  unittest2, strformat,
   ../stew/[bitseqs]
 
 suite "Bit fields":

--- a/tests/test_byteutils.nim
+++ b/tests/test_byteutils.nim
@@ -6,7 +6,7 @@
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
 import
-  std/unittest,
+  unittest2,
   ../stew/byteutils
 
 proc compilationTest {.exportc: "compilationTest".} =

--- a/tests/test_ctops.nim
+++ b/tests/test_ctops.nim
@@ -1,4 +1,4 @@
-import unittest
+import unittest2
 import ../stew/ctops
 
 suite "Constant-time operations test suite":

--- a/tests/test_endians2.nim
+++ b/tests/test_endians2.nim
@@ -1,4 +1,4 @@
-import unittest
+import unittest2
 
 import ../stew/endians2
 

--- a/tests/test_interval_set.nim
+++ b/tests/test_interval_set.nim
@@ -10,7 +10,7 @@
 # distributed except according to those terms.
 
 import
-  std/unittest,
+  unittest2,
   ../stew/interval_set
 
 const

--- a/tests/test_io2.nim
+++ b/tests/test_io2.nim
@@ -1,4 +1,4 @@
-import unittest
+import unittest2
 import ../stew/io2
 
 suite "OS Input/Output procedures test suite":

--- a/tests/test_keyed_queue.nim
+++ b/tests/test_keyed_queue.nim
@@ -9,7 +9,8 @@
 # according to those terms.
 
 import
-  std/[algorithm, sequtils, strformat, strutils, tables, unittest],
+  std/[algorithm, sequtils, strformat, strutils, tables],
+  unittest2,
   ../stew/keyed_queue,
   ../stew/keyed_queue/kq_debug
 

--- a/tests/test_leb128.nim
+++ b/tests/test_leb128.nim
@@ -1,5 +1,5 @@
 import
-  unittest, random,
+  unittest2, random,
   ../stew/[byteutils, leb128, results]
 
 const edgeValues = {

--- a/tests/test_macros.nim
+++ b/tests/test_macros.nim
@@ -1,5 +1,5 @@
 import
-  unittest,
+  unittest2,
   ../stew/shims/macros
 
 

--- a/tests/test_objects.nim
+++ b/tests/test_objects.nim
@@ -1,5 +1,5 @@
 import
-  unittest, typetraits,
+  unittest2, typetraits,
   ../stew/objects
 
 when defined(nimHasUsed):

--- a/tests/test_ptrops.nim
+++ b/tests/test_ptrops.nim
@@ -7,7 +7,7 @@
 #
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
-import unittest
+import unittest2
 
 import ../stew/ptrops
 

--- a/tests/test_sequtils2.nim
+++ b/tests/test_sequtils2.nim
@@ -6,7 +6,7 @@
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
 import
-  std/unittest,
+  unittest2,
   ../stew/sequtils2
 
 suite "sequtils2":

--- a/tests/test_sets.nim
+++ b/tests/test_sets.nim
@@ -1,5 +1,5 @@
 import
-  unittest,
+  unittest2,
   ../stew/shims/sets
 
 suite "shims/sets":

--- a/tests/test_sorted_set.nim
+++ b/tests/test_sorted_set.nim
@@ -11,7 +11,7 @@
 import
   std/[algorithm, sequtils, strformat, tables],
   ../stew/sorted_set,
-  unittest
+  unittest2
 
 const
   keyList = [

--- a/tests/test_templateutils.nim
+++ b/tests/test_templateutils.nim
@@ -1,5 +1,5 @@
 import
-  unittest,
+  unittest2,
   ../stew/templateutils
 
 var computations = newSeq[string]()

--- a/tests/test_varints.nim
+++ b/tests/test_varints.nim
@@ -1,5 +1,5 @@
 import
-  unittest, random,
+  unittest2, random,
   ../stew/[varints, byteutils]
 
 const edgeValues = {

--- a/tests/test_winacl.nim
+++ b/tests/test_winacl.nim
@@ -1,4 +1,4 @@
-import std/unittest
+import unittest2
 import ../stew/io2
 
 when defined(windows):


### PR DESCRIPTION
Global symbol overflow when running NIM 1.2 on Github ci suggests that unit tests run sort of separately. The replacement library `unittest2`  provides that.