### PR TITLE
make it more Nim 1.4+ compatible

### DIFF
--- a/stew/arrayops.nim
+++ b/stew/arrayops.nim
@@ -4,7 +4,7 @@
 #   * Apache v2 license (license terms in the root directory or at http://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
-when (NimMajor, NimMinor) < (1, 6):
+when (NimMajor, NimMinor) < (1, 4):
   {.push raises: [Defect].}
 else:
   {.push raises: [].}

--- a/stew/arrayops.nim
+++ b/stew/arrayops.nim
@@ -1,10 +1,13 @@
-# Copyright (c) 2020 Status Research & Development GmbH
+# Copyright (c) 2020-2022 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at http://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at http://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
-{.push raises: [Defect].}
+when (NimMajor, NimMinor) < (1, 6):
+  {.push raises: [Defect].}
+else:
+  {.push raises: [].}
 
 ## Operations on array and openArray
 

--- a/stew/assign2.nim
+++ b/stew/assign2.nim
@@ -2,7 +2,10 @@ import
   std/typetraits,
   ./shims/macros
 
-{.push raises: [Defect].}
+when (NimMajor, NimMinor) < (1, 6):
+  {.push raises: [Defect].}
+else:
+  {.push raises: [].}
 
 func assign*[T](tgt: var seq[T], src: openArray[T]) {.gcsafe.}
 func assign*[T](tgt: var openArray[T], src: openArray[T]) {.gcsafe.}

--- a/stew/assign2.nim
+++ b/stew/assign2.nim
@@ -2,7 +2,7 @@ import
   std/typetraits,
   ./shims/macros
 
-when (NimMajor, NimMinor) < (1, 6):
+when (NimMajor, NimMinor) < (1, 4):
   {.push raises: [Defect].}
 else:
   {.push raises: [].}

--- a/stew/base10.nim
+++ b/stew/base10.nim
@@ -13,7 +13,7 @@
 import results
 export results
 
-when (NimMajor, NimMinor) < (1, 6):
+when (NimMajor, NimMinor) < (1, 4):
   {.push raises: [Defect].}
 else:
   {.push raises: [].}

--- a/stew/base10.nim
+++ b/stew/base10.nim
@@ -1,4 +1,4 @@
-## Copyright (c) 2021 Status Research & Development GmbH
+## Copyright (c) 2021-2022 Status Research & Development GmbH
 ## Licensed under either of
 ##  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE))
 ##  * MIT license ([LICENSE-MIT](LICENSE-MIT))
@@ -13,7 +13,10 @@
 import results
 export results
 
-{.push raises: [Defect].}
+when (NimMajor, NimMinor) < (1, 6):
+  {.push raises: [Defect].}
+else:
+  {.push raises: [].}
 
 type
   Base10* = object

--- a/stew/bitseqs.nim
+++ b/stew/bitseqs.nim
@@ -1,4 +1,4 @@
-when (NimMajor, NimMinor) < (1, 6):
+when (NimMajor, NimMinor) < (1, 4):
   {.push raises: [Defect].}
 else:
   {.push raises: [].}

--- a/stew/bitseqs.nim
+++ b/stew/bitseqs.nim
@@ -1,4 +1,7 @@
-{.push raises: [Defect].}
+when (NimMajor, NimMinor) < (1, 6):
+  {.push raises: [Defect].}
+else:
+  {.push raises: [].}
 
 import
   bitops2, ptrops

--- a/stew/byteutils.nim
+++ b/stew/byteutils.nim
@@ -16,7 +16,7 @@ import
 # backwards compat
 export arrayops.`&`, arrayops.initArrayWith, arrayops.`[]=`
 
-when (NimMajor, NimMinor) < (1, 6):
+when (NimMajor, NimMinor) < (1, 4):
   {.push raises: [Defect].}
 else:
   {.push raises: [].}

--- a/stew/byteutils.nim
+++ b/stew/byteutils.nim
@@ -16,7 +16,10 @@ import
 # backwards compat
 export arrayops.`&`, arrayops.initArrayWith, arrayops.`[]=`
 
-{.push raises: [Defect].}
+when (NimMajor, NimMinor) < (1, 6):
+  {.push raises: [Defect].}
+else:
+  {.push raises: [].}
 
 ########################################################################################################
 #####################################   Hex utilities   ################################################

--- a/stew/interval_set.nim
+++ b/stew/interval_set.nim
@@ -111,7 +111,7 @@
 import
   "."/[results, sorted_set]
 
-when (NimMajor, NimMinor) < (1, 6):
+when (NimMajor, NimMinor) < (1, 4):
   {.push raises: [Defect].}
 else:
   {.push raises: [].}

--- a/stew/interval_set.nim
+++ b/stew/interval_set.nim
@@ -1,6 +1,6 @@
 # Nimbus - Types, data structures and shared utilities used in network sync
 #
-# Copyright (c) 2018-2021 Status Research & Development GmbH
+# Copyright (c) 2018-2022 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or
 #    http://www.apache.org/licenses/LICENSE-2.0)
@@ -111,7 +111,10 @@
 import
   "."/[results, sorted_set]
 
-{.push raises: [Defect].}
+when (NimMajor, NimMinor) < (1, 6):
+  {.push raises: [Defect].}
+else:
+  {.push raises: [].}
 
 export
   `isRed=`,

--- a/stew/io2.nim
+++ b/stew/io2.nim
@@ -10,7 +10,7 @@
 ## not use exceptions and using Result[T] for error handling.
 ##
 
-when (NimMajor, NimMinor) < (1, 6):
+when (NimMajor, NimMinor) < (1, 4):
   {.push raises: [Defect].}
 else:
   {.push raises: [].}

--- a/stew/io2.nim
+++ b/stew/io2.nim
@@ -1,4 +1,4 @@
-## Copyright (c) 2020 Status Research & Development GmbH
+## Copyright (c) 2020-2022 Status Research & Development GmbH
 ## Licensed under either of
 ##  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE))
 ##  * MIT license ([LICENSE-MIT](LICENSE-MIT))
@@ -10,7 +10,10 @@
 ## not use exceptions and using Result[T] for error handling.
 ##
 
-{.push raises: [Defect].}
+when (NimMajor, NimMinor) < (1, 6):
+  {.push raises: [Defect].}
+else:
+  {.push raises: [].}
 
 import algorithm
 import results

--- a/stew/keyed_queue.nim
+++ b/stew/keyed_queue.nim
@@ -1,5 +1,5 @@
 # Nimbus
-# Copyright (c) 2018 Status Research & Development GmbH
+# Copyright (c) 2018-2022 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or
 #    http://www.apache.org/licenses/LICENSE-2.0)
@@ -29,7 +29,10 @@ import
 export
   results
 
-{.push raises: [Defect].}
+when (NimMajor, NimMinor) < (1, 6):
+  {.push raises: [Defect].}
+else:
+  {.push raises: [].}
 
 type
   KeyedQueueItem*[K,V] = object ##\

--- a/stew/keyed_queue.nim
+++ b/stew/keyed_queue.nim
@@ -29,7 +29,7 @@ import
 export
   results
 
-when (NimMajor, NimMinor) < (1, 6):
+when (NimMajor, NimMinor) < (1, 4):
   {.push raises: [Defect].}
 else:
   {.push raises: [].}

--- a/stew/shims/net.nim
+++ b/stew/shims/net.nim
@@ -5,7 +5,10 @@ type
   ValidIpAddress* {.requiresInit.} = object
     value: IpAddress
 
-{.push raises: [Defect].}
+when (NimMajor, NimMinor) < (1, 6):
+  {.push raises: [Defect].}
+else:
+  {.push raises: [].}
 
 proc ipv4*(address: array[4, byte]): ValidIpAddress =
   ValidIpAddress(value: IpAddress(family: IPv4, address_v4: address))

--- a/stew/shims/net.nim
+++ b/stew/shims/net.nim
@@ -5,7 +5,7 @@ type
   ValidIpAddress* {.requiresInit.} = object
     value: IpAddress
 
-when (NimMajor, NimMinor) < (1, 6):
+when (NimMajor, NimMinor) < (1, 4):
   {.push raises: [Defect].}
 else:
   {.push raises: [].}

--- a/stew/sorted_set.nim
+++ b/stew/sorted_set.nim
@@ -1,5 +1,5 @@
 # Nimbus
-# Copyright (c) 2018 Status Research & Development GmbH
+# Copyright (c) 2018-2022 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or
 #    http://www.apache.org/licenses/LICENSE-2.0)
@@ -87,7 +87,10 @@ type
     ## returned from functions.
     RbResult[SortedSetItemRef[K,V]]
 
-{.push raises: [Defect].}
+when (NimMajor, NimMinor) < (1, 6):
+  {.push raises: [Defect].}
+else:
+  {.push raises: [].}
 
 # ------------------------------------------------------------------------------
 # Private helpers

--- a/stew/sorted_set.nim
+++ b/stew/sorted_set.nim
@@ -87,7 +87,7 @@ type
     ## returned from functions.
     RbResult[SortedSetItemRef[K,V]]
 
-when (NimMajor, NimMinor) < (1, 6):
+when (NimMajor, NimMinor) < (1, 4):
   {.push raises: [Defect].}
 else:
   {.push raises: [].}

--- a/stew/sorted_set/rbtree_delete.nim
+++ b/stew/sorted_set/rbtree_delete.nim
@@ -1,5 +1,5 @@
 # Nimbus
-# Copyright (c) 2018 Status Research & Development GmbH
+# Copyright (c) 2018-2022 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or
 #    http://www.apache.org/licenses/LICENSE-2.0)
@@ -13,7 +13,10 @@ import
   ./rbtree_rotate,
   ../results
 
-{.push raises: [Defect].}
+when (NimMajor, NimMinor) < (1, 6):
+  {.push raises: [Defect].}
+else:
+  {.push raises: [].}
 
 # ------------------------------------------------------------------------------
 # Public

--- a/stew/sorted_set/rbtree_delete.nim
+++ b/stew/sorted_set/rbtree_delete.nim
@@ -13,7 +13,7 @@ import
   ./rbtree_rotate,
   ../results
 
-when (NimMajor, NimMinor) < (1, 6):
+when (NimMajor, NimMinor) < (1, 4):
   {.push raises: [Defect].}
 else:
   {.push raises: [].}

--- a/stew/sorted_set/rbtree_desc.nim
+++ b/stew/sorted_set/rbtree_desc.nim
@@ -170,7 +170,7 @@ type
     start*: bool                       ## `true` after a rewind operation
     stop*: bool                        ## End of traversal
 
-when (NimMajor, NimMinor) < (1, 6):
+when (NimMajor, NimMinor) < (1, 4):
   {.push raises: [Defect].}
 else:
   {.push raises: [].}

--- a/stew/sorted_set/rbtree_desc.nim
+++ b/stew/sorted_set/rbtree_desc.nim
@@ -1,5 +1,5 @@
 # Nimbus
-# Copyright (c) 2018 Status Research & Development GmbH
+# Copyright (c) 2018-2022 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or
 #    http://www.apache.org/licenses/LICENSE-2.0)
@@ -170,7 +170,10 @@ type
     start*: bool                       ## `true` after a rewind operation
     stop*: bool                        ## End of traversal
 
-{.push raises: [Defect].}
+when (NimMajor, NimMinor) < (1, 6):
+  {.push raises: [Defect].}
+else:
+  {.push raises: [].}
 
 # ------------------------------------------------------------------------------
 # Public functions, constructor

--- a/stew/sorted_set/rbtree_find.nim
+++ b/stew/sorted_set/rbtree_find.nim
@@ -12,7 +12,7 @@ import
   ./rbtree_desc,
   ../results
 
-when (NimMajor, NimMinor) < (1, 6):
+when (NimMajor, NimMinor) < (1, 4):
   {.push raises: [Defect].}
 else:
   {.push raises: [].}

--- a/stew/sorted_set/rbtree_find.nim
+++ b/stew/sorted_set/rbtree_find.nim
@@ -1,5 +1,5 @@
 # Nimbus
-# Copyright (c) 2018 Status Research & Development GmbH
+# Copyright (c) 2018-2022 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or
 #    http://www.apache.org/licenses/LICENSE-2.0)
@@ -12,7 +12,10 @@ import
   ./rbtree_desc,
   ../results
 
-{.push raises: [Defect].}
+when (NimMajor, NimMinor) < (1, 6):
+  {.push raises: [Defect].}
+else:
+  {.push raises: [].}
 
 # ----------------------------------------------------------------------- ------
 # Public

--- a/stew/sorted_set/rbtree_flush.nim
+++ b/stew/sorted_set/rbtree_flush.nim
@@ -1,5 +1,5 @@
 # Nimbus
-# Copyright (c) 2018 Status Research & Development GmbH
+# Copyright (c) 2018-2022 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or
 #    http://www.apache.org/licenses/LICENSE-2.0)
@@ -14,7 +14,10 @@ import
 type
   RbTreeFlushDel*[C] = proc(c: var C) {.gcsafe.}
 
-{.push raises: [Defect].}
+when (NimMajor, NimMinor) < (1, 6):
+  {.push raises: [Defect].}
+else:
+  {.push raises: [].}
 
 # ----------------------------------------------------------------------- ------
 # Private

--- a/stew/sorted_set/rbtree_flush.nim
+++ b/stew/sorted_set/rbtree_flush.nim
@@ -14,7 +14,7 @@ import
 type
   RbTreeFlushDel*[C] = proc(c: var C) {.gcsafe.}
 
-when (NimMajor, NimMinor) < (1, 6):
+when (NimMajor, NimMinor) < (1, 4):
   {.push raises: [Defect].}
 else:
   {.push raises: [].}

--- a/stew/sorted_set/rbtree_insert.nim
+++ b/stew/sorted_set/rbtree_insert.nim
@@ -13,7 +13,7 @@ import
   ./rbtree_rotate,
   ../results
 
-when (NimMajor, NimMinor) < (1, 6):
+when (NimMajor, NimMinor) < (1, 4):
   {.push raises: [Defect].}
 else:
   {.push raises: [].}

--- a/stew/sorted_set/rbtree_insert.nim
+++ b/stew/sorted_set/rbtree_insert.nim
@@ -1,5 +1,5 @@
 # Nimbus
-# Copyright (c) 2018 Status Research & Development GmbH
+# Copyright (c) 2018-2022 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or
 #    http://www.apache.org/licenses/LICENSE-2.0)
@@ -13,7 +13,10 @@ import
   ./rbtree_rotate,
   ../results
 
-{.push raises: [Defect].}
+when (NimMajor, NimMinor) < (1, 6):
+  {.push raises: [Defect].}
+else:
+  {.push raises: [].}
 
 # ----------------------------------------------------------------------- ------
 # Private functions

--- a/stew/sorted_set/rbtree_reset.nim
+++ b/stew/sorted_set/rbtree_reset.nim
@@ -13,7 +13,7 @@ import
   ./rbtree_flush,
   ./rbtree_walk
 
-when (NimMajor, NimMinor) < (1, 6):
+when (NimMajor, NimMinor) < (1, 4):
   {.push raises: [Defect].}
 else:
   {.push raises: [].}

--- a/stew/sorted_set/rbtree_reset.nim
+++ b/stew/sorted_set/rbtree_reset.nim
@@ -1,5 +1,5 @@
 # Nimbus
-# Copyright (c) 2018 Status Research & Development GmbH
+# Copyright (c) 2018-2022 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or
 #    http://www.apache.org/licenses/LICENSE-2.0)
@@ -13,7 +13,10 @@ import
   ./rbtree_flush,
   ./rbtree_walk
 
-{.push raises: [Defect].}
+when (NimMajor, NimMinor) < (1, 6):
+  {.push raises: [Defect].}
+else:
+  {.push raises: [].}
 
 # ----------------------------------------------------------------------- ------
 # Public

--- a/stew/sorted_set/rbtree_rotate.nim
+++ b/stew/sorted_set/rbtree_rotate.nim
@@ -11,7 +11,7 @@
 import
   ./rbtree_desc
 
-when (NimMajor, NimMinor) < (1, 6):
+when (NimMajor, NimMinor) < (1, 4):
   {.push raises: [Defect].}
 else:
   {.push raises: [].}

--- a/stew/sorted_set/rbtree_rotate.nim
+++ b/stew/sorted_set/rbtree_rotate.nim
@@ -1,5 +1,5 @@
 # Nimbus
-# Copyright (c) 2018 Status Research & Development GmbH
+# Copyright (c) 2018-2022 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or
 #    http://www.apache.org/licenses/LICENSE-2.0)
@@ -11,7 +11,10 @@
 import
   ./rbtree_desc
 
-{.push raises: [Defect].}
+when (NimMajor, NimMinor) < (1, 6):
+  {.push raises: [Defect].}
+else:
+  {.push raises: [].}
 
 proc rbTreeRotateSingle*[C](node: RbNodeRef[C]; dir: RbDir): RbNodeRef[C] =
   ## Perform a single red-black tree rotation in the specified direction.

--- a/stew/sorted_set/rbtree_verify.nim
+++ b/stew/sorted_set/rbtree_verify.nim
@@ -33,7 +33,7 @@ type
     pr: RbPrnFn
     msg: string              ## collect data
 
-when (NimMajor, NimMinor) < (1, 6):
+when (NimMajor, NimMinor) < (1, 4):
   {.push raises: [Defect].}
 else:
   {.push raises: [].}

--- a/stew/sorted_set/rbtree_verify.nim
+++ b/stew/sorted_set/rbtree_verify.nim
@@ -1,5 +1,5 @@
 # Nimbus
-# Copyright (c) 2018 Status Research & Development GmbH
+# Copyright (c) 2018-2022 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or
 #    http://www.apache.org/licenses/LICENSE-2.0)
@@ -33,7 +33,10 @@ type
     pr: RbPrnFn
     msg: string              ## collect data
 
-{.push raises: [Defect].}
+when (NimMajor, NimMinor) < (1, 6):
+  {.push raises: [Defect].}
+else:
+  {.push raises: [].}
 
 # ----------------------------------------------------------------------- ------
 # Private

--- a/stew/sorted_set/rbtree_walk.nim
+++ b/stew/sorted_set/rbtree_walk.nim
@@ -13,7 +13,7 @@ import
   ./rbtree_desc,
   ../results
 
-when (NimMajor, NimMinor) < (1, 6):
+when (NimMajor, NimMinor) < (1, 4):
   {.push raises: [Defect].}
 else:
   {.push raises: [].}

--- a/stew/sorted_set/rbtree_walk.nim
+++ b/stew/sorted_set/rbtree_walk.nim
@@ -1,5 +1,5 @@
 # Nimbus
-# Copyright (c) 2018 Status Research & Development GmbH
+# Copyright (c) 2018-2022 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or
 #    http://www.apache.org/licenses/LICENSE-2.0)
@@ -13,7 +13,10 @@ import
   ./rbtree_desc,
   ../results
 
-{.push raises: [Defect].}
+when (NimMajor, NimMinor) < (1, 6):
+  {.push raises: [Defect].}
+else:
+  {.push raises: [].}
 
 # ----------------------------------------------------------------------- ------
 # Priv


### PR DESCRIPTION
A continuation of https://github.com/status-im/nimbus-eth2/pull/3888

Rationale (from that link):

> Currently (the latest commit in unstable branch), the CI log for the 1.6 branch has **107.000 lines**.
Removing every hint about cannot raise 'Defect' (including the ones in the vendor directory) leaves **16.000 lines**. 85% off.