### PR TITLE
Revert "Normalise `KeyError` exception message"

### DIFF
--- a/stew/keyed_queue.nim
+++ b/stew/keyed_queue.nim
@@ -380,12 +380,14 @@ proc delete*[K,V](rq: var KeyedQueue[K,V]; key: K):
   ## Delete the item with key `key` from the queue and returns the key-value
   ## item pair just deleted (if any).
   if rq.tab.hasKey(key):
-    noKeyError("delete"):
+    try:
       let kvp = KeyedQueuePair[K,V](
         key: key,
         data: rq.tab[key].data)
       rq.deleteImpl(key)
       return ok(kvp)
+    except KeyError:
+      raiseAssert "We've checked that the key is present above"
   err()
 
 proc del*[K,V](rq: var KeyedQueue[K,V]; key: K) =


### PR DESCRIPTION
Reverts status-im/nim-stew#119

See if this re-establishes CI passing. If so, I intend to merge it.

It's a nice enough change, it's fine, and if it points to some compiler bug which needs to be fixed, that's useful, but it can/should be done in a branch that's not named `master`.