### PR TITLE
support multiple nim version re. nnkArgList issue

### DIFF
--- a/stew.nimble
+++ b/stew.nimble
@@ -12,31 +12,17 @@ requires "nim >= 1.2.0",
 
 ### Helper functions
 proc test(args, path: string) =
-  # nnkArglist was changed to nnkArgList, so can't always use --styleCheck:error
-  # https://github.com/nim-lang/Nim/pull/17529
-  # https://github.com/nim-lang/Nim/pull/19822
-  let styleCheckStyle =
-    if (NimMajor, NimMinor) < (1, 6):
-      "hint"
-    else:
-      "error"
-
   # Compilation language is controlled by TEST_LANG
   exec "nim " & getEnv("TEST_LANG", "c") & " " & getEnv("NIMFLAGS") &
        " " & args &
-       " -r --hints:off --skipParentCfg --styleCheck:usages --styleCheck:" &
-       styleCheckStyle & " " & path
+       " -r --hints:off --skipParentCfg --styleCheck:usages --styleCheck:error" &
+       " " & path
 
 proc buildHelper(args, path: string) =
-  let styleCheckStyle =
-    if (NimMajor, NimMinor) < (1, 6):
-      "hint"
-    else:
-      "error"
   exec "nim " & getEnv("TEST_LANG", "c") & " " & getEnv("NIMFLAGS") &
        " " & args &
-       " --hints:off --skipParentCfg --styleCheck:usages --styleCheck:" &
-       styleCheckStyle & " " & path
+       " --hints:off --skipParentCfg --styleCheck:usages --styleCheck:error" &
+       " " & path
 
 task test, "Run all tests":
   # Building `test_helper.nim`.

--- a/stew/shims/macros.nim
+++ b/stew/shims/macros.nim
@@ -414,11 +414,19 @@ iterator baseTypes*(exceptionType: NimNode): NimNode =
     yield typ
 
 macro unpackArgs*(callee: untyped, args: untyped): untyped =
+  # nnkArglist was changed to nnkArgList
+  # https://github.com/nim-lang/Nim/pull/17529
+  # https://github.com/nim-lang/Nim/pull/19822
+  const ArgKind = when (NimMajor, NimMinor) < (1, 6):
+                    nnkArglist
+                  else:
+                    nnkArgList
+
   result = newCall(callee)
   for arg in args:
     let arg = if arg.kind == nnkHiddenStdConv: arg[1]
               else: arg
-    if arg.kind == nnkArgList:
+    if arg.kind == ArgKind:
       for subarg in arg:
         result.add subarg
     else:


### PR DESCRIPTION
Many libraries depends on `unpackArgs` e.g. serialization family, those serialization also became dependency of other libraries. 
It is easier to fix the problem here, instead of each of those libraries have to enable/disable `styleCheck` of their own.