### PR TITLE
chore: fix 'there should not be `high(value)`. use `high(type)`' deprecation

### DIFF
--- a/stew/sorted_set/rbtree_desc.nim
+++ b/stew/sorted_set/rbtree_desc.nim
@@ -194,7 +194,7 @@ proc newRbTreeRef*[C,K](cmp: RbCmpFn[C,K]; mkc: RbMkcFn[C,K]): RbTreeRef[C,K] =
 proc newWalkId*[C,K](rbt: RbTreeRef[C,K]): uint {.inline.} =
   ## Generate new free walk ID, returns zero in (theoretical) case all other
   ## IDs are exhausted.
-  for id in rbt.walkIdGen .. rbt.walkIdGen.high:
+  for id in rbt.walkIdGen .. high(type rbt.walkIdGen):
     if not rbt.walks.hasKey(id):
       rbt.walkIdGen = id
       return id


### PR DESCRIPTION
In _nwaku_ we have been using nim 1.6 for some time. This fixes the following deprecation warning:

```
/nwaku/vendor/nim-stew/stew/sorted_set/rbtree_desc.nim(197, 30) Warning: Deprecated since v1.4; there should not be `high(value)`. Use `high(type)`.; high is deprecated [Deprecated]
```