### PR TITLE
Deprecate baseType

### DIFF
--- a/stew/objects.nim
+++ b/stew/objects.nim
@@ -59,15 +59,15 @@ when not compiles(len((1, 2))):
 # Get an object's base type, as a cstring. Ref objects will have an ":ObjectType"
 # suffix.
 # From: https://gist.github.com/stefantalpalaru/82dc71bb547d6f9178b916e3ed5b527d
-proc baseType*(obj: RootObj): cstring {.deprecated.} =
+proc baseType*[T: RootObj](obj: T): cstring {.deprecated.} =
   when not defined(nimTypeNames):
-    raiseAssert("you need to compile this with '-d:nimTypeNames'")
+    {.error: "baseType requires -d:nimTypeNames".}
   when defined(gcArc) or defined(gcOrc):
-    raiseAssert("baseType doesn't work with arc / orc")
+    {.error: "baseType doesn't work with arc / orc".}
   else:
     {.emit: "result = `obj`->m_type->name;".}
 
-proc baseType*(obj: ref RootObj): cstring {.deprecated.} =
+proc baseType*[T: RootObj](obj: ref T): cstring {.deprecated.} =
   obj[].baseType
 
 macro enumRangeInt64*(a: type[enum]): untyped =

--- a/stew/objects.nim
+++ b/stew/objects.nim
@@ -59,13 +59,13 @@ when not compiles(len((1, 2))):
 # Get an object's base type, as a cstring. Ref objects will have an ":ObjectType"
 # suffix.
 # From: https://gist.github.com/stefantalpalaru/82dc71bb547d6f9178b916e3ed5b527d
-proc baseType*(obj: RootObj): cstring =
+proc baseType*(obj: RootObj): cstring {.deprecated.} =
   when not defined(nimTypeNames):
     raiseAssert("you need to compile this with '-d:nimTypeNames'")
   else:
     {.emit: "result = `obj`->m_type->name;".}
 
-proc baseType*(obj: ref RootObj): cstring =
+proc baseType*(obj: ref RootObj): cstring {.deprecated.} =
   obj[].baseType
 
 macro enumRangeInt64*(a: type[enum]): untyped =

--- a/stew/objects.nim
+++ b/stew/objects.nim
@@ -59,16 +59,18 @@ when not compiles(len((1, 2))):
 # Get an object's base type, as a cstring. Ref objects will have an ":ObjectType"
 # suffix.
 # From: https://gist.github.com/stefantalpalaru/82dc71bb547d6f9178b916e3ed5b527d
-proc baseType*[T: RootObj](obj: T): cstring {.deprecated.} =
-  when not defined(nimTypeNames):
-    {.error: "baseType requires -d:nimTypeNames".}
-  when defined(gcArc) or defined(gcOrc):
-    {.error: "baseType doesn't work with arc / orc".}
-  else:
+when not defined(nimTypeNames):
+  proc baseType*(obj: RootObj): cstring {.error: "baseType requires -d:nimTypeNames".}
+  proc baseType*(obj: ref RootObj): cstring {.error: "baseType requires -d:nimTypeNames".}
+elif defined(gcArc) or defined(gcOrc):
+  proc baseType*(obj: RootObj): cstring {.error: "baseType is not available in ARC/ORC".}
+  proc baseType*(obj: ref RootObj): cstring {.error: "baseType is not available in ARC/ORC".}
+else:
+  proc baseType*(obj: RootObj): cstring {.deprecated.} =
     {.emit: "result = `obj`->m_type->name;".}
 
-proc baseType*[T: RootObj](obj: ref T): cstring {.deprecated.} =
-  obj[].baseType
+  proc baseType*(obj: ref RootObj): cstring {.deprecated.} =
+    obj[].baseType
 
 macro enumRangeInt64*(a: type[enum]): untyped =
   ## This macro returns an array with all the ordinal values of an enum

--- a/stew/objects.nim
+++ b/stew/objects.nim
@@ -62,7 +62,7 @@ when not compiles(len((1, 2))):
 proc baseType*(obj: RootObj): cstring {.deprecated.} =
   when not defined(nimTypeNames):
     raiseAssert("you need to compile this with '-d:nimTypeNames'")
-  when defined(arc) or defined(orc):
+  when defined(gcArc) or defined(gcOrc):
     raiseAssert("baseType doesn't work with arc / orc")
   else:
     {.emit: "result = `obj`->m_type->name;".}

--- a/stew/objects.nim
+++ b/stew/objects.nim
@@ -62,6 +62,8 @@ when not compiles(len((1, 2))):
 proc baseType*(obj: RootObj): cstring {.deprecated.} =
   when not defined(nimTypeNames):
     raiseAssert("you need to compile this with '-d:nimTypeNames'")
+  when defined(arc) or defined(orc):
+    raiseAssert("baseType doesn't work with arc / orc")
   else:
     {.emit: "result = `obj`->m_type->name;".}
 

--- a/tests/test_objects.nim
+++ b/tests/test_objects.nim
@@ -12,32 +12,33 @@ suite "Objects":
     when (not defined(nimTypeNames)) or defined(gcOrc) or defined(gcArc):
       skip()
       return
-    type
-      Foo = ref object of RootObj
-      Bar = ref object of Foo
-      Baz = object of RootObj
-      Bob = object of Baz
-      Bill = ref object of Bob
+    else:
+      type
+        Foo = ref object of RootObj
+        Bar = ref object of Foo
+        Baz = object of RootObj
+        Bob = object of Baz
+        Bill = ref object of Bob
 
-    var
-      foo = Foo()
-      bar = Bar()
-      baz = Baz()
-      bob = Bob()
-      bill = Bill()
+      var
+        foo = Foo()
+        bar = Bar()
+        baz = Baz()
+        bob = Bob()
+        bill = Bill()
 
-    check:
-      foo.baseType == "Foo:ObjectType"
-      bar.baseType == "Bar:ObjectType"
-      baz.baseType == "Baz"
-      bob.baseType == "Bob"
-      bill.baseType == "Bill:ObjectType"
+      check:
+        foo.baseType == "Foo:ObjectType"
+        bar.baseType == "Bar:ObjectType"
+        baz.baseType == "Baz"
+        bob.baseType == "Bob"
+        bill.baseType == "Bill:ObjectType"
 
-    proc f(o: Foo) =
-      check $o.type == "Foo"
-      check o.baseType == "Bar:ObjectType"
+      proc f(o: Foo) =
+        check $o.type == "Foo"
+        check o.baseType == "Bar:ObjectType"
 
-    f(bar)
+      f(bar)
 
   test "declval":
     type

--- a/tests/test_objects.nim
+++ b/tests/test_objects.nim
@@ -9,6 +9,9 @@ when defined(nimHasUsed):
 
 suite "Objects":
   test "baseType":
+    when (not defined(nimTypeNames)) or defined(gcOrc) or defined(gcArc):
+      skip()
+      return
     type
       Foo = ref object of RootObj
       Bar = ref object of Foo
@@ -23,19 +26,18 @@ suite "Objects":
       bob = Bob()
       bill = Bill()
 
-    when defined(nimTypeNames):
-      check:
-        foo.baseType == "Foo:ObjectType"
-        bar.baseType == "Bar:ObjectType"
-        baz.baseType == "Baz"
-        bob.baseType == "Bob"
-        bill.baseType == "Bill:ObjectType"
+    check:
+      foo.baseType == "Foo:ObjectType"
+      bar.baseType == "Bar:ObjectType"
+      baz.baseType == "Baz"
+      bob.baseType == "Bob"
+      bill.baseType == "Bill:ObjectType"
 
-      proc f(o: Foo) =
-        check $o.type == "Foo"
-        check o.baseType == "Bar:ObjectType"
+    proc f(o: Foo) =
+      check $o.type == "Foo"
+      check o.baseType == "Bar:ObjectType"
 
-      f(bar)
+    f(bar)
 
   test "declval":
     type


### PR DESCRIPTION
From a quick sweep in our repos, no one uses it
It's based on quite unsafe behavior, doesn't give the same results with arc/orc, and I'm pretty sure a macro could do it, if we need it