### PR TITLE
Remove lock file

### DIFF
--- a/nimble.lock
+++ b/nimble.lock
@@ -1,4 +1,0 @@
-{
-  "version": 1,
-  "packages": {}
-}


### PR DESCRIPTION
The lock file breaks devel testing - CI updates are needed as well as a strategy for handling "nim important packages" builds (which build with a version of Nim different from that in the lock file)