### PR TITLE
byteutils: fix memleak

### DIFF
--- a/stew/byteutils.nim
+++ b/stew/byteutils.nim
@@ -246,12 +246,11 @@ func toBytes*(s: string): seq[byte] =
   ## nim essentially are byte sequences without any particular encoding, this
   ## simply copies the bytes without a null terminator
   when nimvm:
-    var r = newSeq[byte](s.len)
+    result = newSeq[byte](s.len)
     for i, c in s:
-      r[i] = cast[byte](c)
-    r
+      result[i] = cast[byte](c)
   else:
-    @(s.toOpenArrayByte(0, s.high))
+    result = @(s.toOpenArrayByte(0, s.high))
 
 func fromBytes*(T: type string, v: openArray[byte]): string =
   if v.len > 0:


### PR DESCRIPTION
the implicit form leaks memory
```nim
@(s.toOpenArrayByte(0, s.high))
```

the explicit `result =` doesn't
```nim
result = @(s.toOpenArrayByte(0, s.high))
```

Minimal example:

``` nim
import stew/byteutils

echo "hello".toBytes
```

``` shell
nim c --mm:orc -d:useMalloc example
valgrind --leak-check=full ./example

==28198== HEAP SUMMARY:
==28198==     in use at exit: 13 bytes in 1 blocks
==28198==   total heap usage: 7 allocs, 6 frees, 1,161 bytes allocated
==28198== 
==28198== 13 bytes in 1 blocks are definitely lost in loss record 1 of 1
==28198==    at 0x48455EF: calloc (vg_replace_malloc.c:1328)
==28198==    by 0x10AB1A: alloc0Impl__system_1770 (in /home/user/programming/example)
==28198==    by 0x10AB44: allocShared0Impl__system_1783 (in /home/user/programming/example)
==28198==    by 0x1104C2: alignedAlloc0__system_1948 (in /home/user/programming/example)
==28198==    by 0x1107AB: newSeqPayload (in /home/user/programming/example)
==28198==    by 0x110BBF: prepareSeqAdd (in /home/user/programming/example)
==28198==    by 0x111108: setLen__OOZOnimbleZpkgs50Zstew4548O49O4845f5353e53d5057bdfe494956bbc49cabac5751cf5052b485753565556cb49ZstewZbyteutils_150 (in /home/user/programming/example)
==28198==    by 0x11126C: newSeq__OOZOnimbleZpkgs50Zstew4548O49O4845f5353e53d5057bdfe494956bbc49cabac5751cf5052b485753565556cb49ZstewZbyteutils_142 (in /home/user/programming/example)
==28198==    by 0x11130C: at___OOZOnimbleZpkgs50Zstew4548O49O4845f5353e53d5057bdfe494956bbc49cabac5751cf5052b485753565556cb49ZstewZbyteutils_389 (in /home/user/programming/example)
==28198==    by 0x1120C9: toBytes__OOZOnimbleZpkgs50Zstew4548O49O4845f5353e53d5057bdfe494956bbc49cabac5751cf5052b485753565556cb49ZstewZbyteutils_376 (in /home/user/programming/example)
==28198==    by 0x1122D4: NimMainModule (in /home/user/programming/example)
==28198==    by 0x1121F3: NimMainInner (in /home/user/programming/example)
==28198== 
==28198== LEAK SUMMARY:
==28198==    definitely lost: 13 bytes in 1 blocks
==28198==    indirectly lost: 0 bytes in 0 blocks
==28198==      possibly lost: 0 bytes in 0 blocks
==28198==    still reachable: 0 bytes in 0 blocks
==28198==         suppressed: 0 bytes in 0 blocks
```