### PR TITLE
don't mark `declval` as `{.compileTime.}`

### DIFF
--- a/stew/objects.nim
+++ b/stew/objects.nim
@@ -29,7 +29,7 @@ template anonConst*(val: untyped): untyped =
   const c = val
   c
 
-func declval*(T: type): T {.compileTime.} =
+func declval*(T: type): T =
   ## `declval` denotes an anonymous expression of a particular
   ## type. It can be used in situations where you want to determine
   ## the type of an overloaded call in `typeof` expressions.


### PR DESCRIPTION
`declval` is meant to be used to determine types of expressions, and never be executed (https://github.com/status-im/nim-stew/pull/33). However it's marked `{.compileTime.}`, which would normally make it always execute during constant folding, but due to a bug in Nim (https://github.com/nim-lang/Nim/issues/10753), generic procs like `declval` do not undergo constant folding. So the `{.compileTime.}` annotation is removed for this to work when the bug in Nim is fixed.

(Unfortunately this still only errors at execution time, I don't know a mechanism that errors at compile time but only outside typeof/concepts)