### PR TITLE
fix `ProveField` warnings in `results`

### DIFF
--- a/stew/results.nim
+++ b/stew/results.nim
@@ -355,23 +355,19 @@ func raiseResultError[T, E](self: Result[T, E]) {.noreturn, noinline.} =
   # site
   mixin toException
 
-  case self.oResultPrivate
-  of false:
-    when E is ref Exception:
-      if self.eResultPrivate.isNil: # for example Result.default()!
-        raise (ref ResultError[void])(msg: "Trying to access value with err (nil)")
-      raise self.eResultPrivate
-    elif E is void:
-      raise (ref ResultError[void])(msg: "Trying to access value with err")
-    elif compiles(toException(self.eResultPrivate)):
-      raise toException(self.eResultPrivate)
-    elif compiles($self.eResultPrivate):
-      raise (ref ResultError[E])(
-        error: self.eResultPrivate, msg: $self.eResultPrivate)
-    else:
-      raise (ref ResultError[E])(msg: "Trying to access value with err", error: self.eResultPrivate)
-  of true:
-    raiseAssert "Unreachable"
+  when E is ref Exception:
+    if self.eResultPrivate.isNil: # for example Result.default()!
+      raise (ref ResultError[void])(msg: "Trying to access value with err (nil)")
+    raise self.eResultPrivate
+  elif E is void:
+    raise (ref ResultError[void])(msg: "Trying to access value with err")
+  elif compiles(toException(self.eResultPrivate)):
+    raise toException(self.eResultPrivate)
+  elif compiles($self.eResultPrivate):
+    raise (ref ResultError[E])(
+      error: self.eResultPrivate, msg: $self.eResultPrivate)
+  else:
+    raise (ref ResultError[E])(msg: "Trying to access value with err", error: self.eResultPrivate)
 
 func raiseResultDefect(m: string, v: auto) {.noreturn, noinline.} =
   mixin `$`


### PR DESCRIPTION
Nim emits `ProveField` warnings with `if` on case object discriminator. Replace with `case` instead to avoid those warnings. Note we currently have `ProveField` disabled but it keeps showing up sometimes when compiling with `nim c` instead of `make`.