### PR TITLE
unconditionally pass through std/os and deprecate shim/os

### DIFF
--- a/stew/shims/os.nim
+++ b/stew/shims/os.nim
@@ -1,18 +1,3 @@
+{.deprecated: "use std/os".}
 import std/os
 export os
-
-when defined(windows):
-  import winlean
-else:
-  import posix
-
-when not declared(getCurrentProcessId):
-  proc getCurrentProcessId*(): int =
-    ## return current process ID. See also ``osproc.processID(p: Process)``.
-    when defined(windows):
-      proc GetCurrentProcessId(): DWORD {.stdcall, dynlib: "kernel32",
-                                        importc: "GetCurrentProcessId".}
-      GetCurrentProcessId().int
-    else:
-      getpid()
-


### PR DESCRIPTION
Nim 1.2 and newer unconditionally [define](https://github.com/nim-lang/Nim/blob/version-1-2/lib/pure/os.nim#L3204) and [document  `getCurrentProcessId`](https://nim-lang.org/docs/os.html#getCurrentProcessId):
```nim
proc getCurrentProcessId*(): int {.noWeirdTarget.} =
  ## Return current process ID.
  ##
  ## See also:
  ## * `osproc.processID(p: Process) <osproc.html#processID,Process>`_
  when defined(windows):
    proc GetCurrentProcessId(): DWORD {.stdcall, dynlib: "kernel32",
                                        importc: "GetCurrentProcessId".}
    result = GetCurrentProcessId().int
  else:
    result = getpid()
```

which adds some comments, uses `result = foo`, and explicitly checks via `.noWeirdTarget.` for some cases in which the `nim-stew` shim won't work either, but is otherwise functionally equivalent.