### PR TITLE
don't require init on `ValidIpAddress`

### DIFF
--- a/stew/shims/net.nim
+++ b/stew/shims/net.nim
@@ -2,7 +2,7 @@ import std/net as stdNet
 export stdNet
 
 type
-  ValidIpAddress* {.requiresInit.} = object
+  ValidIpAddress* = object
     value: IpAddress
 
 {.push raises: [].}

--- a/stew/shims/net.nim
+++ b/stew/shims/net.nim
@@ -2,7 +2,7 @@ import std/net as stdNet
 export stdNet
 
 type
-  ValidIpAddress* = object
+  ValidIpAddress* {.requiresInit, deprecated.} = object
     value: IpAddress
 
 {.push raises: [].}


### PR DESCRIPTION
See https://github.com/status-im/nimbus-eth2/pull/5536 for the warnings this triggers.

They're not spurious/false positives, either. `nim-eth` (https://github.com/nim-lang/Nim/issues/22883 affects it since it uses sets and tables with `ValidIpAddress`, `nim-confutils`, and `nim-toml-serialization` all depend on `default(ValidIpAddress)` working, in ways which extend into Nim's standard library.