### PR TITLE
mark stew/shims/net as deprecated

### DIFF
--- a/stew/shims/net.nim
+++ b/stew/shims/net.nim
@@ -1,3 +1,5 @@
+{.deprecated: "use std/net".}
+
 import std/net as stdNet
 export stdNet
 


### PR DESCRIPTION
This module exists to support `ValidIpAddress`, which is deprecated. Otherwise, using `std/net` is equivalent.