### PR TITLE
rename `RangeError` -> `RangeDefect` in test name

### DIFF
--- a/tests/ranges/tstackarrays.nim
+++ b/tests/ranges/tstackarrays.nim
@@ -32,7 +32,7 @@ suite "Stack arrays":
       arr[^1] == 6
       cast[ptr int](offset(addr arr[0], 5))[] == 10
 
-  test "Allocating with a negative size throws a RangeError":
+  test "Allocating with a negative size throws a RangeDefect":
     expect RangeDefect:
       discard allocStackArray(string, -1)
 


### PR DESCRIPTION
The `Allocating with a negative size throws a RangeError` test actually tests for `RangeDefect`, so rename the test accordingly.