### PR TITLE
rm deprecated pre-Nim 1.6 shims

### DIFF
--- a/stew/shims/atomics.nim
+++ b/stew/shims/atomics.nim
@@ -1,3 +1,0 @@
-{.deprecated: "use std/atomics".}
-import std/concurrency/atomics
-export atomics

--- a/stew/shims/enumutils.nim
+++ b/stew/shims/enumutils.nim
@@ -1,3 +1,0 @@
-{.deprecated: "use std/enumutils".}
-import std/enumutils
-export enumutils

--- a/stew/shims/stddefects.nim
+++ b/stew/shims/stddefects.nim
@@ -1,1 +1,0 @@
-{.deprecated: "Nim 1.4 and newer support FooDefect directly".}

--- a/stew/shims/typetraits.nim
+++ b/stew/shims/typetraits.nim
@@ -1,3 +1,0 @@
-{.deprecated: "use std/typetraits".}
-import std/typetraits
-export typetraits


### PR DESCRIPTION
Followup to
- https://github.com/status-im/nim-stew/pull/205
- https://github.com/status-im/nim-stew/pull/206

It's been virtually a year now, and the updates required in each case are trivial, since
- https://github.com/status-im/nim-stew/pull/204

means people using current commits of `stew` already must be using Nim 1.6 or newer.