### PR TITLE
Fix Windows ACL flakiness issue (Windows error 1336).

### DIFF
--- a/stew/io2.nim
+++ b/stew/io2.nim
@@ -1642,7 +1642,7 @@ proc getTempPath*(): IoResult[string] =
       ok(strpath)
   else:
     for name in ["TMP", "TEMP", "TMPDIR", "TEMPDIR"]:
-      let res = c_getenv(name)
+      let res = c_getenv(cstring(name))
       if not(isNil(res)) and isDir($res):
         var path = $res
         normPathEnd(path, true)

--- a/stew/windows/acl.nim
+++ b/stew/windows/acl.nim
@@ -143,13 +143,13 @@ proc free*(sd: var SD) =
   ## Free memory occupied by security descriptor.
   discard sd.sddata.free()
   discard sd.acldata.free()
-  sd.sddata = nil
-  sd.acldata = nil
+  sd.sddata = LocalMemPtr(nil)
+  sd.acldata = LocalMemPtr(nil)
 
 proc free*(sid: var SID) =
   ## Free memory occupied by security identifier.
   discard sid.data.free()
-  sid.data = nil
+  sid.data = LocalMemPtr(nil)
 
 proc getTokenInformation(token: uint,
                          information: uint32): IoResult[LocalMemPtr] =

--- a/tests/test_io2.nim
+++ b/tests/test_io2.nim
@@ -768,3 +768,22 @@ suite "OS Input/Output procedures test suite":
       isDir(destDir) == false
       isDir(firstDir) == false
       isFile(destFile) == false
+
+  test "getHomePath() test":
+    let res = getHomePath()
+    check:
+      res.isOk()
+      len(res.get()) > 0
+
+  test "getConfigPath() test":
+    let res = getConfigPath()
+    check:
+      res.isOk()
+      len(res.get()) > 0
+
+  test "getCachePath() test":
+    let res = getCachePath()
+    check:
+      res.isOk()
+      len(res.get()) > 0
+

--- a/tests/test_io2.nim
+++ b/tests/test_io2.nim
@@ -787,3 +787,8 @@ suite "OS Input/Output procedures test suite":
       res.isOk()
       len(res.get()) > 0
 
+  test "getTempPath() test":
+    let res = getTempPath()
+    check:
+      res.isOk()
+      len(res.get()) > 0


### PR DESCRIPTION
Fix Windows ACL flakiness issue.
Add getHomePath(), getConfigPath(), getCachePath() and getTempPath() helpers.
