### PR TITLE
fix deprecation warnings from results; deprecate shims/io module; rm deprecated shims/os module

### DIFF
--- a/stew/base10.nim
+++ b/stew/base10.nim
@@ -1,4 +1,4 @@
-## Copyright (c) 2021-2023 Status Research & Development GmbH
+## Copyright (c) 2021-2024 Status Research & Development GmbH
 ## Licensed under either of
 ##  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE))
 ##  * MIT license ([LICENSE-MIT](LICENSE-MIT))
@@ -10,7 +10,7 @@
 ##
 ## Encoding procedures are adopted versions of C functions described here:
 ## # https://www.facebook.com/notes/facebook-engineering/three-optimization-tips-for-c/10151361643253920
-import results
+import pkg/results
 export results
 
 {.push raises: [].}
@@ -39,7 +39,7 @@ type
     data*: array[maxLen(Base10, T), byte]
     len*: int8 # >= 1 when holding valid unsigned integer
 
-proc decode*[A: byte|char, T: SomeUnsignedInt](
+func decode*[A: byte|char, T: SomeUnsignedInt](
     B: typedesc[Base10], t: typedesc[T],
     src: openArray[A]): Result[T, cstring] =
   ## Convert base10 encoded string or array of bytes to unsigned integer.
@@ -62,7 +62,7 @@ proc decode*[A: byte|char, T: SomeUnsignedInt](
     v = (v shl 3) + (v shl 1) + T(d)
   ok(v)
 
-proc encodedLength*(B: typedesc[Base10], value: SomeUnsignedInt): int8 =
+func encodedLength*(B: typedesc[Base10], value: SomeUnsignedInt): int8 =
   ## Procedure returns number of characters needed to encode integer ``value``.
   when type(value) is uint8:
     if value < 10'u8:
@@ -132,7 +132,7 @@ proc encodedLength*(B: typedesc[Base10], value: SomeUnsignedInt): int8 =
       return 11'i8 + (if value >= P11: 1'i8 else: 0)
     return 12'i8 + B.encodedLength(value div P12)
 
-proc encode[A: byte|char](B: typedesc[Base10], value: SomeUnsignedInt,
+func encode[A: byte|char](B: typedesc[Base10], value: SomeUnsignedInt,
                           output: var openArray[A],
                           length: int8): Result[int8, cstring] =
   const Digits = cstring(
@@ -175,25 +175,25 @@ proc encode[A: byte|char](B: typedesc[Base10], value: SomeUnsignedInt,
       output[next - 1] = byte(Digits[index])
   ok(length)
 
-proc encode*[A: byte|char](B: typedesc[Base10], value: SomeUnsignedInt,
+func encode*[A: byte|char](B: typedesc[Base10], value: SomeUnsignedInt,
                            output: var openArray[A]): Result[int8, cstring] =
   ## Encode integer value to array of characters or bytes.
   B.encode(value, output, B.encodedLength(value))
 
-proc toString*(B: typedesc[Base10], value: SomeUnsignedInt): string =
+func toString*(B: typedesc[Base10], value: SomeUnsignedInt): string =
   ## Encode integer value ``value`` to string.
   var buf = newString(B.encodedLength(value))
   # Buffer of proper size is allocated, so error is not possible
   discard B.encode(value, buf, int8(len(buf)))
   buf
 
-proc toBytes*[I: SomeUnsignedInt](B: typedesc[Base10], v: I): Base10Buf[I] {.
+func toBytes*[I: SomeUnsignedInt](B: typedesc[Base10], v: I): Base10Buf[I] {.
      noinit.} =
   ## Encode integer value ``value`` to array of bytes.
   let res = B.encode(v, result.data, B.encodedLength(v))
   result.len = int8(res.get())
 
-proc toBytes*[I: SomeUnsignedInt](v: I, B: typedesc[Base10]): Base10Buf[I] {.
+func toBytes*[I: SomeUnsignedInt](v: I, B: typedesc[Base10]): Base10Buf[I] {.
      noinit.} =
   ## Encode integer value ``value`` to array of bytes.
   let res = B.encode(v, result.data, B.encodedLength(v))

--- a/stew/io.nim
+++ b/stew/io.nim
@@ -1,3 +1,5 @@
+{.deprecated: "use https://nim-lang.org/docs/syncio.html#writeFile%2Cstring%2CopenArray%5Bbyte%5D directly".}
+
 when not compiles(writeFile("filename", @[byte(1)])):
   proc writeFile*(filename: string, content: openArray[byte]) =
     ## Opens a file named `filename` for writing. Then writes the
@@ -11,4 +13,3 @@ when not compiles(writeFile("filename", @[byte(1)])):
         close(f)
     else:
       raise newException(IOError, "cannot open: " & filename)
-

--- a/stew/io2.nim
+++ b/stew/io2.nim
@@ -1,4 +1,4 @@
-## Copyright (c) 2020-2023 Status Research & Development GmbH
+## Copyright (c) 2020-2024 Status Research & Development GmbH
 ## Licensed under either of
 ##  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE))
 ##  * MIT license ([LICENSE-MIT](LICENSE-MIT))
@@ -12,8 +12,8 @@
 
 {.push raises: [].}
 
-import algorithm
-import results
+import std/algorithm
+import pkg/results
 export results
 
 when defined(windows):

--- a/stew/keyed_queue.nim
+++ b/stew/keyed_queue.nim
@@ -1,5 +1,5 @@
 # Nimbus
-# Copyright (c) 2018-2023 Status Research & Development GmbH
+# Copyright (c) 2018-2024 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or
 #    http://www.apache.org/licenses/LICENSE-2.0)
@@ -22,11 +22,11 @@
 ## semantics, this means that `=` performs a deep copy of the allocated queue
 ## which is refered to the deep copy semantics of the underlying table driver.
 
-import std/tables, results
+{.push raises: [].}
+
+import std/tables, pkg/results
 
 export results
-
-{.push raises: [].}
 
 type
   KeyedQueueItem*[K, V] = object

--- a/stew/keyed_queue/kq_debug.nim
+++ b/stew/keyed_queue/kq_debug.nim
@@ -1,5 +1,5 @@
 # Nimbus
-# Copyright (c) 2018-2023 Status Research & Development GmbH
+# Copyright (c) 2018-2024 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or
 #    http://www.apache.org/licenses/LICENSE-2.0)
@@ -12,10 +12,12 @@
 ## =============================
 ##
 
+{.push raises: [].}
+
 import
   std/tables,
-  ../keyed_queue,
-  ../results
+  results,
+  ../keyed_queue
 
 type
   KeyedQueueInfo* = enum ##\
@@ -31,13 +33,11 @@ type
     kQVfyPrvNxtExpected
     kQVfyFirstExpected
 
-{.push raises: [].}
-
 # ------------------------------------------------------------------------------
 # Public functions, debugging
 # ------------------------------------------------------------------------------
 
-proc `$`*[K,V](item: KeyedQueueItem[K,V]): string =
+func `$`*[K,V](item: KeyedQueueItem[K,V]): string =
   ## Pretty print data container item.
   ##
   ## :CAVEAT:
@@ -51,8 +51,8 @@ proc `$`*[K,V](item: KeyedQueueItem[K,V]): string =
   else:
     "(" & $item.value & ", link[" & $item.prv & "," & $item.kNxt & "])"
 
-proc verify*[K,V](rq: var KeyedQueue[K,V]): Result[void,(K,V,KeyedQueueInfo)]
-    {.gcsafe,raises: [KeyError].} =
+func verify*[K,V](rq: var KeyedQueue[K,V]): Result[void,(K,V,KeyedQueueInfo)]
+    {.raises: [KeyError].} =
   ## Check for consistency. Returns an error unless the argument
   ## queue `rq` is consistent.
   let tabLen = rq.tab.len
@@ -97,7 +97,7 @@ proc verify*[K,V](rq: var KeyedQueue[K,V]): Result[void,(K,V,KeyedQueueInfo)]
 
   ok()
 
-proc dumpLinkedKeys*[K,V](rq: var KeyedQueue[K,V]): string =
+func dumpLinkedKeys*[K,V](rq: var KeyedQueue[K,V]): string =
   ## Dump the linked key list. This function depends on the `$` operator
   ## for converting a `K` type into a string
   if 0 < rq.tab.len:

--- a/stew/shims/os.nim
+++ b/stew/shims/os.nim
@@ -1,3 +1,0 @@
-{.deprecated: "use std/os".}
-import std/os
-export os

--- a/stew/sorted_set/rbtree_delete.nim
+++ b/stew/sorted_set/rbtree_delete.nim
@@ -1,5 +1,5 @@
 # Nimbus
-# Copyright (c) 2018-2023 Status Research & Development GmbH
+# Copyright (c) 2018-2024 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or
 #    http://www.apache.org/licenses/LICENSE-2.0)
@@ -8,18 +8,18 @@
 # at your option. This file may not be copied, modified, or distributed except
 # according to those terms.
 
-import
-  ./rbtree_desc,
-  ./rbtree_rotate,
-  ../results
-
 {.push raises: [].}
+
+import
+  results,
+  ./rbtree_desc,
+  ./rbtree_rotate
 
 # ------------------------------------------------------------------------------
 # Public
 # ------------------------------------------------------------------------------
 
-proc rbTreeDelete*[C,K](rbt: RbTreeRef[C,K]; key: K): RbResult[C] =
+func rbTreeDelete*[C,K](rbt: RbTreeRef[C,K]; key: K): RbResult[C] =
   ## Generic red-black tree function, removes a node from the red-black tree.
   ## The node to be removed wraps a data container `casket` matching the
   ## argument `key`, i.e. `rbt.cmp(casket,key) == 0`.

--- a/stew/sorted_set/rbtree_desc.nim
+++ b/stew/sorted_set/rbtree_desc.nim
@@ -1,5 +1,5 @@
 # Nimbus
-# Copyright (c) 2018-2023 Status Research & Development GmbH
+# Copyright (c) 2018-2024 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or
 #    http://www.apache.org/licenses/LICENSE-2.0)
@@ -67,9 +67,11 @@
 #   anyone who has modified the code through
 #   a header comment, such as this one.typedef
 
+{.push raises: [].}
+
 import
-  std/[tables],
-  ../results
+  results,
+  std/[tables]
 
 const
   rbTreeReBalancedFlag* = 1
@@ -176,7 +178,7 @@ type
 # Public functions, constructor
 # ------------------------------------------------------------------------------
 
-proc newRbTreeRef*[C,K](cmp: RbCmpFn[C,K]; mkc: RbMkcFn[C,K]): RbTreeRef[C,K] =
+func newRbTreeRef*[C,K](cmp: RbCmpFn[C,K]; mkc: RbMkcFn[C,K]): RbTreeRef[C,K] =
   ## Constructor. Create generic red-black tree descriptor for data container
   ## type `C` and key type `K`. Details about the function arguments `cmpFn`
   ## and `mkcFn` are documented with the type definitions of `RbCmpFn` and
@@ -188,7 +190,7 @@ proc newRbTreeRef*[C,K](cmp: RbCmpFn[C,K]; mkc: RbMkcFn[C,K]): RbTreeRef[C,K] =
     walks: initTable[uint,RbWalkRef[C,K]](1))
 
 
-proc newWalkId*[C,K](rbt: RbTreeRef[C,K]): uint {.inline.} =
+func newWalkId*[C,K](rbt: RbTreeRef[C,K]): uint {.inline.} =
   ## Generate new free walk ID, returns zero in (theoretical) case all other
   ## IDs are exhausted.
   for id in rbt.walkIdGen .. high(type rbt.walkIdGen):
@@ -205,12 +207,12 @@ proc newWalkId*[C,K](rbt: RbTreeRef[C,K]): uint {.inline.} =
 # Public handlers
 # ------------------------------------------------------------------------------
 
-proc cmp*[C,K](rbt: RbTreeRef[C,K]; casket: C; key: K): int {.inline.} =
+func cmp*[C,K](rbt: RbTreeRef[C,K]; casket: C; key: K): int {.inline.} =
   ## See introduction for an explanation of opaque argument types `C` and `D`,
   ## and the type definition for `RbCmpFn` for properties of this function.
   rbt.cmpFn(casket, key)
 
-proc mkc*[C,K](rbt: RbTreeRef[C,K]; key: K): C {.inline.} =
+func mkc*[C,K](rbt: RbTreeRef[C,K]; key: K): C {.inline.} =
   ## See introduction for an explanation of opaque argument/return types `C`
   ## and `D`, and the type definition for `RbMkdFn` for properties of this
   ## function.
@@ -220,15 +222,15 @@ proc mkc*[C,K](rbt: RbTreeRef[C,K]; key: K): C {.inline.} =
 # Public getters
 # ------------------------------------------------------------------------------
 
-proc linkLeft*[C](node: RbNodeRef[C]): RbNodeRef[C] {.inline.} =
+func linkLeft*[C](node: RbNodeRef[C]): RbNodeRef[C] {.inline.} =
   ## Getter, shortcut for `node.link[rbLeft]`
   node.link[rbLeft]
 
-proc linkRight*[C](node: RbNodeRef[C]): RbNodeRef[C] {.inline.} =
+func linkRight*[C](node: RbNodeRef[C]): RbNodeRef[C] {.inline.} =
   ## Getter, shortcut for `node.link[rbRight]`
   node.link[rbRight]
 
-proc isRed*[C](node: RbNodeRef[C]): bool {.inline.} =
+func isRed*[C](node: RbNodeRef[C]): bool {.inline.} =
   ## Getter, `true` if node colour is read.
   not node.isNil and node.redColour
 
@@ -236,15 +238,15 @@ proc isRed*[C](node: RbNodeRef[C]): bool {.inline.} =
 # Public setters
 # ------------------------------------------------------------------------------
 
-proc `linkLeft=`*[C](node, child: RbNodeRef[C]) {.inline.} =
+func `linkLeft=`*[C](node, child: RbNodeRef[C]) {.inline.} =
   ## Getter, shortcut for `node.link[rbLeft] = child`
   node.link[rbLeft] = child
 
-proc `linkRight=`*[C](node, child: RbNodeRef[C]) {.inline.} =
+func `linkRight=`*[C](node, child: RbNodeRef[C]) {.inline.} =
   ## Getter, shortcut for `node.link[rbRight] = child`
   node.link[rbRight] = child
 
-proc `isRed=`*[C](node: RbNodeRef[C]; value: bool) {.inline.} =
+func `isRed=`*[C](node: RbNodeRef[C]; value: bool) {.inline.} =
   ## Setter, `true` sets red node colour.
   node.redColour = value
 
@@ -252,11 +254,11 @@ proc `isRed=`*[C](node: RbNodeRef[C]; value: bool) {.inline.} =
 # Public helpers: `rbDir` as array index
 # ------------------------------------------------------------------------------
 
-proc `not`*(d: RbDir): RbDir {.inline.} =
+func `not`*(d: RbDir): RbDir {.inline.} =
   ## Opposite direction of argument `d`.
   if d == rbLeft: rbRight else: rbLeft
 
-proc toDir*(b: bool): RbDir {.inline.} =
+func toDir*(b: bool): RbDir {.inline.} =
   ## Convert to link diection `rbLeft` (false) or `rbRight` (true).
   if b: rbRight else: rbLeft
 
@@ -264,7 +266,7 @@ proc toDir*(b: bool): RbDir {.inline.} =
 # Public pretty printer
 # ------------------------------------------------------------------------------
 
-proc `$`*[C](node: RbNodeRef[C]): string =
+func `$`*[C](node: RbNodeRef[C]): string =
   ## Pretty printer, requres `$()` for type `C` to be known.
   if node.isNil:
     return "nil"
@@ -276,7 +278,7 @@ proc `$`*[C](node: RbNodeRef[C]): string =
     "left=" & $node.linkLeft & "," &
     "right=" & $node.linkRight  & ")"
 
-proc `$`*[C,K](rbt: RbTreeRef[C,K]): string =
+func `$`*[C,K](rbt: RbTreeRef[C,K]): string =
   ## Pretty printer
   if rbt.isNil:
     return "nil"
@@ -285,7 +287,7 @@ proc `$`*[C,K](rbt: RbTreeRef[C,K]): string =
     "gen=" & $rbt.walkIdGen & "," &
     "root=" & $rbt.root & "]"
 
-proc `$`*[C,K](w: RbWalkRef[C,K]): string =
+func `$`*[C,K](w: RbWalkRef[C,K]): string =
   ## Pretty printer
   if w.isNil:
     return "nil"

--- a/stew/sorted_set/rbtree_find.nim
+++ b/stew/sorted_set/rbtree_find.nim
@@ -1,5 +1,5 @@
 # Nimbus
-# Copyright (c) 2018-2023 Status Research & Development GmbH
+# Copyright (c) 2018-2024 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or
 #    http://www.apache.org/licenses/LICENSE-2.0)
@@ -8,17 +8,17 @@
 # at your option. This file may not be copied, modified, or distributed except
 # according to those terms.
 
-import
-  ./rbtree_desc,
-  ../results
-
 {.push raises: [].}
+
+import
+  results,
+  ./rbtree_desc
 
 # ----------------------------------------------------------------------- ------
 # Public
 # ------------------------------------------------------------------------------
 
-proc rbTreeFindEq*[C,K](rbt: RbTreeRef[C,K]; key: K): RbResult[C] =
+func rbTreeFindEq*[C,K](rbt: RbTreeRef[C,K]; key: K): RbResult[C] =
   ## Generic red-black tree function. Search for a data container `casket` of
   ## type `C` in the red black tree which matches the argument `key`,
   ## i.e. `rbt.cmp(casket,key) == 0`. If found, this data container `casket` is
@@ -51,7 +51,7 @@ proc rbTreeFindEq*[C,K](rbt: RbTreeRef[C,K]; key: K): RbResult[C] =
   return err(rbNotFound)
 
 
-proc rbTreeFindGe*[C,K](rbt: RbTreeRef[C,K]; key: K): RbResult[C] =
+func rbTreeFindGe*[C,K](rbt: RbTreeRef[C,K]; key: K): RbResult[C] =
   ## Generic red-black tree function. Search for the *smallest* data container
   ## `casket` of type `C` which is *greater or equal* to the specified argument
   ## `key` in the red black-tree. If such a  data container is found in the
@@ -109,7 +109,7 @@ proc rbTreeFindGe*[C,K](rbt: RbTreeRef[C,K]; key: K): RbResult[C] =
   return err(rbNotFound)
 
 
-proc rbTreeFindGt*[C,K](rbt: RbTreeRef[C,K]; key: K): RbResult[C] =
+func rbTreeFindGt*[C,K](rbt: RbTreeRef[C,K]; key: K): RbResult[C] =
   ## Generic red-black tree function. Search for the *smallest* data container
   ## of type `C` which is *strictly greater* than the specified argument `key`
   ## in the red-black tree.
@@ -148,7 +148,7 @@ proc rbTreeFindGt*[C,K](rbt: RbTreeRef[C,K]; key: K): RbResult[C] =
   return err(rbNotFound)
 
 
-proc rbTreeFindLe*[C,K](rbt: RbTreeRef[C,K]; key: K): RbResult[C] =
+func rbTreeFindLe*[C,K](rbt: RbTreeRef[C,K]; key: K): RbResult[C] =
   ## Generic red-black tree function. Search for the *greatest* data container
   ## of type `C` which is *less than or equal* to the specified argument
   ## `key` in the red-black tree.
@@ -190,7 +190,7 @@ proc rbTreeFindLe*[C,K](rbt: RbTreeRef[C,K]; key: K): RbResult[C] =
   return err(rbNotFound)
 
 
-proc rbTreeFindLt*[C,K](rbt: RbTreeRef[C,K]; key: K): RbResult[C] =
+func rbTreeFindLt*[C,K](rbt: RbTreeRef[C,K]; key: K): RbResult[C] =
   ## Generic red-black tree function. Search for the *greatest* data container
   ## of type `C` which is *strictly less* than the specified argument `key` in
   ## the red-black tree.

--- a/stew/sorted_set/rbtree_insert.nim
+++ b/stew/sorted_set/rbtree_insert.nim
@@ -1,5 +1,5 @@
 # Nimbus
-# Copyright (c) 2018-2023 Status Research & Development GmbH
+# Copyright (c) 2018-2024 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or
 #    http://www.apache.org/licenses/LICENSE-2.0)
@@ -8,25 +8,25 @@
 # at your option. This file may not be copied, modified, or distributed except
 # according to those terms.
 
-import
-  ./rbtree_desc,
-  ./rbtree_rotate,
-  ../results
-
 {.push raises: [].}
+
+import
+  results,
+  ./rbtree_desc,
+  ./rbtree_rotate
 
 # ----------------------------------------------------------------------- ------
 # Private functions
 # ------------------------------------------------------------------------------
 
-proc insertRoot[C,K](rbt: RbTreeRef[C,K]; key: K): C {.inline.} =
+func insertRoot[C,K](rbt: RbTreeRef[C,K]; key: K): C {.inline.} =
   ## Insert item `x` into an empty tree.
   rbt.root = RbNodeRef[C](
     casket: rbt.mkc(key))
   rbt.size = 1
   rbt.root.casket
 
-proc insertNode[C,K](rbt: RbTreeRef[C,K]; key: K): RbResult[C] {.inline.} =
+func insertNode[C,K](rbt: RbTreeRef[C,K]; key: K): RbResult[C] {.inline.} =
   ## Insert item `key` into a non-empty tree.
 
   doAssert not rbt.root.isNil
@@ -108,7 +108,7 @@ proc insertNode[C,K](rbt: RbTreeRef[C,K]; key: K): RbResult[C] {.inline.} =
 # Public
 # ------------------------------------------------------------------------------
 
-proc rbTreeInsert*[C,K](rbt: RbTreeRef[C,K]; key: K): RbResult[C] =
+func rbTreeInsert*[C,K](rbt: RbTreeRef[C,K]; key: K): RbResult[C] =
   ## Generic red-black tree function, inserts a data container `casket` derived
   ## from argument `key` into the red-black tree.
   ##

--- a/stew/sorted_set/rbtree_verify.nim
+++ b/stew/sorted_set/rbtree_verify.nim
@@ -1,5 +1,5 @@
 # Nimbus
-# Copyright (c) 2018-2023 Status Research & Development GmbH
+# Copyright (c) 2018-2024 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or
 #    http://www.apache.org/licenses/LICENSE-2.0)
@@ -8,9 +8,11 @@
 # at your option. This file may not be copied, modified, or distributed except
 # according to those terms.
 
+{.push raises: [].}
+
 import
-  ./rbtree_desc,
-  ../results
+  results,
+  ./rbtree_desc
 
 type
   RbLtFn*[C] = ##\
@@ -40,7 +42,7 @@ type
 # Private
 # ------------------------------------------------------------------------------
 
-proc pp[C](n: RbNodeRef[C]): string =
+func pp[C](n: RbNodeRef[C]): string =
   if n.isNil:
     return "nil"
   result = $n.casket

--- a/stew/sorted_set/rbtree_walk.nim
+++ b/stew/sorted_set/rbtree_walk.nim
@@ -1,5 +1,5 @@
 # Nimbus
-# Copyright (c) 2018-2023 Status Research & Development GmbH
+# Copyright (c) 2018-2024 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or
 #    http://www.apache.org/licenses/LICENSE-2.0)
@@ -8,18 +8,18 @@
 # at your option. This file may not be copied, modified, or distributed except
 # according to those terms.
 
-import
-  std/[tables],
-  ./rbtree_desc,
-  ../results
-
 {.push raises: [].}
+
+import
+  results,
+  std/[tables],
+  ./rbtree_desc
 
 # ----------------------------------------------------------------------- ------
 # Priv
 # ------------------------------------------------------------------------------
 
-proc walkMove[C,K](w: RbWalkRef[C,K]; dir: RbDir): RbResult[C] =
+func walkMove[C,K](w: RbWalkRef[C,K]; dir: RbDir): RbResult[C] =
   ## Traverse a red black tree in the user-specified direction.
   ##
   ## :Returns:
@@ -62,7 +62,7 @@ proc walkMove[C,K](w: RbWalkRef[C,K]; dir: RbDir): RbResult[C] =
   return err(rbEndOfWalk)
 
 
-proc walkStart[C,K](w: RbWalkRef[C,K]; dir: RbDir): RbResult[C] =
+func walkStart[C,K](w: RbWalkRef[C,K]; dir: RbDir): RbResult[C] =
   ## Rewind the traversal position to the left-most or-right-most position
   ## as defined by the function argument `dir`. After successfully rewinding,
   ## the desriptor is in `start` position (see `walkClearDirty()`).
@@ -94,7 +94,7 @@ proc walkStart[C,K](w: RbWalkRef[C,K]; dir: RbDir): RbResult[C] =
   return ok(w.node.casket)
 
 
-proc walkClearDirtyFlags[C,K](w: RbWalkRef[C,K]): bool =
+func walkClearDirtyFlags[C,K](w: RbWalkRef[C,K]): bool =
   ## Clear dirty flag if all traversal descriptors are in `start` postion.
   if w.tree.dirty != 0:
     for u in w.tree.walks.values:
@@ -110,7 +110,7 @@ proc walkClearDirtyFlags[C,K](w: RbWalkRef[C,K]): bool =
 # Public constructor/desctructor
 # ------------------------------------------------------------------------------
 
-proc newRbWalk*[C,K](rbt: RbTreeRef[C,K]): RbWalkRef[C,K] =
+func newRbWalk*[C,K](rbt: RbTreeRef[C,K]): RbWalkRef[C,K] =
   ## Generic red-black tree function, creates a new traversal descriptor on the
   ## argument red-black tree `rbt`.
   ##
@@ -127,7 +127,7 @@ proc newRbWalk*[C,K](rbt: RbTreeRef[C,K]): RbWalkRef[C,K] =
   rbt.walks[result.id] = result     # register in parent descriptor
 
 
-proc rbWalkDestroy*[C,K](w: RbWalkRef[C,K]) =
+func rbWalkDestroy*[C,K](w: RbWalkRef[C,K]) =
   ## Explicit destructor for current walk descriptor `w`. Clears the descriptor
   ## argument `w`.
   ##
@@ -142,7 +142,7 @@ proc rbWalkDestroy*[C,K](w: RbWalkRef[C,K]) =
     w.path = @[]
     w[].reset
 
-proc rbWalkDestroyAll*[C,K](rbt: RbTreeRef[C,K]) =
+func rbWalkDestroyAll*[C,K](rbt: RbTreeRef[C,K]) =
   ## Apply `rbWalkDestroy()` to all registered walk descriptors.
   for w in rbt.walks.values:
     w.tree = nil # notify GC (if any, todo?)
@@ -151,7 +151,7 @@ proc rbWalkDestroyAll*[C,K](rbt: RbTreeRef[C,K]) =
     w[].reset    # clear
   rbt.walks = initTable[uint,RbWalkRef[C,K]](1)
 
-proc rbWalkDestroyAll*[C,K](w: RbWalkRef[C,K]) =
+func rbWalkDestroyAll*[C,K](w: RbWalkRef[C,K]) =
   ## Variant of `rbWalkDestroyAll()`
   if not w.tree.isNil:
     w.tree.rbWalkDestroyAll
@@ -160,7 +160,7 @@ proc rbWalkDestroyAll*[C,K](w: RbWalkRef[C,K]) =
 # Public functions: rewind
 # ------------------------------------------------------------------------------
 
-proc rbWalkFirst*[C,K](w: RbWalkRef[C,K]): RbResult[C] =
+func rbWalkFirst*[C,K](w: RbWalkRef[C,K]): RbResult[C] =
   ## Move to the beginning of the tree (*smallest* item) and return the
   ## corresponding data container of type `C`.
   ##
@@ -181,7 +181,7 @@ proc rbWalkFirst*[C,K](w: RbWalkRef[C,K]): RbResult[C] =
   return w.walkStart(rbLeft)
 
 
-proc rbWalkLast*[C,K](w: RbWalkRef[C,K]): RbResult[C] =
+func rbWalkLast*[C,K](w: RbWalkRef[C,K]): RbResult[C] =
   ## Move to the end of the tree (*greatest* item) and return the corresponding
   ## data container of type `C`.
   ##
@@ -205,7 +205,7 @@ proc rbWalkLast*[C,K](w: RbWalkRef[C,K]): RbResult[C] =
 # Public functions: traversal, get data entry
 # ------------------------------------------------------------------------------
 
-proc rbWalkCurrent*[C,K](w: RbWalkRef[C,K]): RbResult[C] =
+func rbWalkCurrent*[C,K](w: RbWalkRef[C,K]): RbResult[C] =
   ## Retrieves the data container of type `C` for the current node. Note that
   ## the current node becomes unavailable if it was recently deleted.
   ##
@@ -222,7 +222,7 @@ proc rbWalkCurrent*[C,K](w: RbWalkRef[C,K]): RbResult[C] =
 
 
 
-proc rbWalkNext*[C,K](w: RbWalkRef[C,K]): RbResult[C] =
+func rbWalkNext*[C,K](w: RbWalkRef[C,K]): RbResult[C] =
   ## Traverse to the next value in ascending order and return the corresponding
   ## data container of type `C`. If this is the first call after `newRbWalk()`,
   ## then `rbWalkFirst()` is called implicitly.
@@ -253,7 +253,7 @@ proc rbWalkNext*[C,K](w: RbWalkRef[C,K]): RbResult[C] =
   return w.walkStart(rbLeft) # minimum index item
 
 
-proc rbWalkPrev*[C,K](w: RbWalkRef[C,K]): RbResult[C] =
+func rbWalkPrev*[C,K](w: RbWalkRef[C,K]): RbResult[C] =
   ## Traverse to the next value in descending order and return the
   ## corresponding data container of type `C`. If this is the first call
   ## after `newRbWalk()`, then `rbWalkLast()` is called implicitly.

--- a/tests/test_helper.nim
+++ b/tests/test_helper.nim
@@ -1,11 +1,12 @@
-# Copyright (c) 2020-2022 Status Research & Development GmbH
+# Copyright (c) 2020-2024 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license: http://opensource.org/licenses/MIT
 #   * Apache License, Version 2.0: http://www.apache.org/licenses/LICENSE-2.0
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
 import std/[os, strutils]
-import ../stew/io2, ../stew/results
+import pkg/results
+import ../stew/io2
 
 proc lockFileFlags(path: string, flags: set[OpenFlags],
                    lockType: LockType): IoResult[void] =


### PR DESCRIPTION
- https://github.com/status-im/nim-stew/pull/199 deprecated `shims/os` a year ago
- `shims/io` was effectively a workaround for pre-Nim 1.2, or maybe even pre-Nim 1.0. Been several years since it's mattered. The stdlib's [writeFile()](https://nim-lang.org/docs/syncio.html#writeFile%2Cstring%2CopenArray%5Bbyte%5D) can be used as an exact replacement. Verified that under Nim 1.6 and Nim 2.0, that `when` branch doesn't even trigger, so it's been a no-op of an import.