### PR TITLE
modernize some modules

### DIFF
--- a/stew.nimble
+++ b/stew.nimble
@@ -18,7 +18,7 @@ let verbose = getEnv("V", "") notin ["", "0"]
 
 let cfg =
   " --styleCheck:usages --styleCheck:error" &
-  (if verbose: "" else: " --verbosity:0 --hints:off") &
+  (if verbose: "" else: " --verbosity:0") &
   " --skipParentCfg --skipUserCfg --outdir:build --nimcache:build/nimcache -f"
 
 proc build(args, path: string) =

--- a/stew/base32.nim
+++ b/stew/base32.nim
@@ -1,4 +1,4 @@
-## Copyright (c) 2018 Status Research & Development GmbH
+## Copyright (c) 2018-2025 Status Research & Development GmbH
 ## Licensed under either of
 ##  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE))
 ##  * MIT license ([LICENSE-MIT](LICENSE-MIT))
@@ -6,8 +6,8 @@
 ## This file may not be copied, modified, or distributed except according to
 ## those terms.
 
-## This module implements BASE32 encoding and decoding procedures.
-## This module supports RFC4648's BASE32.
+## This module implements Base32 encoding and decoding procedures.
+## This module supports RFC4648's Base32.
 
 type
   Base32Status* {.pure.} = enum
@@ -50,7 +50,7 @@ type
   Base32Error* = object of CatchableError
     ## Base32 specific exception type
 
-proc newAlphabet32*(s: string): Base32Alphabet =
+func newAlphabet32*(s: string): Base32Alphabet =
   doAssert(len(s) == 32)
   for i in 0..<len(s):
     result.encode[i] = cast[uint8](s[i])
@@ -65,8 +65,8 @@ const
   HEXUpperCaseAlphabet* = newAlphabet32("0123456789ABCDEFGHIJKLMNOPQRSTUV")
   HEXLowerCaseAlphabet* = newAlphabet32("0123456789abcdefghijklmnopqrstuv")
 
-proc encodedLength*(btype: typedesc[Base32Types], length: int): int =
-  ## Return estimated length of BASE32 encoded value for plain length
+func encodedLength*(btype: typedesc[Base32Types], length: int): int =
+  ## Return estimated length of Base32 encoded value for plain length
   ## ``length``.
   let reminder = length mod 5
   when btype is Base32NoPadTypes:
@@ -76,13 +76,13 @@ proc encodedLength*(btype: typedesc[Base32Types], length: int): int =
     if reminder != 0:
       result += 8
 
-proc decodedLength*(btype: typedesc[Base32Types], length: int): int =
-  ## Return estimated length of decoded value of BASE32 encoded value of length
+func decodedLength*(btype: typedesc[Base32Types], length: int): int =
+  ## Return estimated length of decoded value of Base32 encoded value of length
   ## ``length``.
   let reminder = length mod 8
   result = (length div 8) * 5 + ((reminder * 5) div 8)
 
-proc convert5to8(inbytes: openArray[byte], outbytes: var openArray[char],
+func convert5to8(inbytes: openArray[byte], outbytes: var openArray[char],
                  length: int): int {.inline.} =
   if length >= 1:
     outbytes[0] = chr(inbytes[0] shr 3)
@@ -107,7 +107,7 @@ proc convert5to8(inbytes: openArray[byte], outbytes: var openArray[char],
     outbytes[7] = chr(inbytes[4] and 31'u8)
     result = 8
 
-proc convert8to5(inbytes: openArray[byte], outbytes: var openArray[byte],
+func convert8to5(inbytes: openArray[byte], outbytes: var openArray[byte],
                  length: int): int {.inline.} =
   if length >= 2:
     outbytes[0] = inbytes[0] shl 3
@@ -132,9 +132,9 @@ proc convert8to5(inbytes: openArray[byte], outbytes: var openArray[byte],
     outbytes[4] = outbytes[4] or (inbytes[7] and 31'u8)
     result = 5
 
-proc encode*(btype: typedesc[Base32Types], inbytes: openArray[byte],
+func encode*(btype: typedesc[Base32Types], inbytes: openArray[byte],
              outstr: var openArray[char], outlen: var int): Base32Status =
-  ## Encode array of bytes ``inbytes`` using BASE32 encoding and store
+  ## Encode array of bytes ``inbytes`` using Base32 encoding and store
   ## result to ``outstr``. On success ``Base32Status.Success`` will be returned
   ## and ``outlen`` will be set to number of characters stored inside of
   ## ``outstr``. If length of ``outstr`` is not enough then
@@ -183,9 +183,9 @@ proc encode*(btype: typedesc[Base32Types], inbytes: openArray[byte],
   outlen = k
   result = Base32Status.Success
 
-proc encode*(btype: typedesc[Base32Types],
+func encode*(btype: typedesc[Base32Types],
              inbytes: openArray[byte]): string {.inline.} =
-  ## Encode array of bytes ``inbytes`` using BASE32 encoding and return
+  ## Encode array of bytes ``inbytes`` using Base32 encoding and return
   ## encoded string.
   if len(inbytes) == 0:
     result = ""
@@ -197,9 +197,9 @@ proc encode*(btype: typedesc[Base32Types],
     else:
       result = ""
 
-proc decode*[T: byte|char](btype: typedesc[Base32Types], instr: openArray[T],
+func decode*[T: byte|char](btype: typedesc[Base32Types], instr: openArray[T],
              outbytes: var openArray[byte], outlen: var int): Base32Status =
-  ## Decode BASE32 string and store array of bytes to ``outbytes``. On success
+  ## Decode Base32 string and store array of bytes to ``outbytes``. On success
   ## ``Base32Status.Success`` will be returned and ``outlen`` will be set
   ## to number of bytes stored.
   ##
@@ -270,9 +270,9 @@ proc decode*[T: byte|char](btype: typedesc[Base32Types], instr: openArray[T],
   outlen = k + left
   result = Base32Status.Success
 
-proc decode*[T: byte|char](btype: typedesc[Base32Types],
+func decode*[T: byte|char](btype: typedesc[Base32Types],
                            instr: openArray[T]): seq[byte] =
-  ## Decode BASE32 string ``instr`` and return sequence of bytes as result.
+  ## Decode Base32 string ``instr`` and return sequence of bytes as result.
   if len(instr) == 0:
     result = newSeq[byte]()
   else:

--- a/stew/base58.nim
+++ b/stew/base58.nim
@@ -1,4 +1,4 @@
-## Copyright (c) 2018 Status Research & Development GmbH
+## Copyright (c) 2018-2025 Status Research & Development GmbH
 ## Licensed under either of
 ##  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE))
 ##  * MIT license ([LICENSE-MIT](LICENSE-MIT))
@@ -6,8 +6,8 @@
 ## This file may not be copied, modified, or distributed except according to
 ## those terms.
 
-## This module implements BASE58 encoding and decoding procedures.
-## This module supports two variants of BASE58 encoding (Bitcoin and Flickr).
+## This module implements Base58 encoding and decoding procedures.
+## This module supports two variants of Base58 encoding (Bitcoin and Flickr).
 
 type
   Base58Status* {.pure.} = enum
@@ -32,7 +32,7 @@ type
   Base58Error* = object of CatchableError
     ## Base58 specific exception type
 
-proc newAlphabet58*(s: string): Base58Alphabet =
+func newAlphabet58*(s: string): Base58Alphabet =
   doAssert(len(s) == 58)
   for i in 0..<len(s):
     result.encode[i] = cast[uint8](s[i])
@@ -47,19 +47,19 @@ const
   FlickrAlphabet* = newAlphabet58("123456789abcdefghijkmnopqrstu" &
                                   "vwxyzABCDEFGHJKLMNPQRSTUVWXYZ")
 
-proc encodedLength*(btype: typedesc[Base58C], length: int): int =
-  ## Return estimated length of BASE58 encoded value for plain length
+func encodedLength*(btype: typedesc[Base58C], length: int): int =
+  ## Return estimated length of Base58 encoded value for plain length
   ## ``length``.
   result = (length * 138) div 100 + 1
 
-proc decodedLength*(btype: typedesc[Base58C], length: int): int =
-  ## Return estimated length of decoded value of BASE58 encoded value of length
+func decodedLength*(btype: typedesc[Base58C], length: int): int =
+  ## Return estimated length of decoded value of Base58 encoded value of length
   ## ``length``.
   result = length + 4
 
-proc encode*(btype: typedesc[Base58C], inbytes: openArray[byte],
+func encode*(btype: typedesc[Base58C], inbytes: openArray[byte],
              outstr: var openArray[char], outlen: var int): Base58Status =
-  ## Encode array of bytes ``inbytes`` using BASE58 encoding and store
+  ## Encode array of bytes ``inbytes`` using Base58 encoding and store
   ## result to ``outstr``. On success ``Base58Status.Success`` will be returned
   ## and ``outlen`` will be set to number of characters stored inside of
   ## ``outstr``. If length of ``outstr`` is not enough then
@@ -111,9 +111,9 @@ proc encode*(btype: typedesc[Base58C], inbytes: openArray[byte],
       inc(i)
     result = Base58Status.Success
 
-proc encode*(btype: typedesc[Base58C],
+func encode*(btype: typedesc[Base58C],
              inbytes: openArray[byte]): string {.inline.} =
-  ## Encode array of bytes ``inbytes`` using BASE58 encoding and return
+  ## Encode array of bytes ``inbytes`` using Base58 encoding and return
   ## encoded string.
   var size = (len(inbytes) * 138) div 100 + 1
   result = newString(size)
@@ -123,15 +123,15 @@ proc encode*(btype: typedesc[Base58C],
   else:
     result = ""
 
-proc decode*[T: byte|char](btype: typedesc[Base58C], instr: openArray[T],
+func decode*[T: byte|char](btype: typedesc[Base58C], instr: openArray[T],
              outbytes: var openArray[byte], outlen: var int): Base58Status =
-  ## Decode BASE58 string and store array of bytes to ``outbytes``. On success
+  ## Decode Base58 string and store array of bytes to ``outbytes``. On success
   ## ``Base58Status.Success`` will be returned and ``outlen`` will be set
   ## to number of bytes stored.
   ##
   ## Length of ``outbytes`` must be equal or more then ``len(instr) + 4``.
   ##
-  ## If ``instr`` has characters which are not part of BASE58 alphabet, then
+  ## If ``instr`` has characters which are not part of Base58 alphabet, then
   ## ``Base58Status.Incorrect`` will be returned and ``outlen`` will be set to
   ## ``0``.
   ##
@@ -227,8 +227,8 @@ proc decode*[T: byte|char](btype: typedesc[Base58C], instr: openArray[T],
   outlen += zcount
   result = Base58Status.Success
 
-proc decode*(btype: typedesc[Base58C], instr: string): seq[byte] =
-  ## Decode BASE58 string ``instr`` and return sequence of bytes as result.
+func decode*(btype: typedesc[Base58C], instr: string): seq[byte] =
+  ## Decode Base58 string ``instr`` and return sequence of bytes as result.
   if len(instr) > 0:
     var size = len(instr) + 4
     result = newSeq[byte](size)

--- a/stew/base64.nim
+++ b/stew/base64.nim
@@ -1,4 +1,4 @@
-## Copyright (c) 2018 Status Research & Development GmbH
+## Copyright (c) 2018-2025 Status Research & Development GmbH
 ## Licensed under either of
 ##  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE))
 ##  * MIT license ([LICENSE-MIT](LICENSE-MIT))
@@ -6,7 +6,7 @@
 ## This file may not be copied, modified, or distributed except according to
 ## those terms.
 
-## This module implements BASE64 encoding and decoding procedures.
+## This module implements Base64 encoding and decoding procedures.
 
 type
   Base64Status* {.pure.} = enum
@@ -38,7 +38,7 @@ type
   Base64Error* = object of CatchableError
     ## Base64 specific exception type
 
-proc newAlphabet64*(s: string): Base64Alphabet =
+func newAlphabet64*(s: string): Base64Alphabet =
   doAssert(len(s) == 64)
   for i in 0..<len(s):
     result.encode[i] = cast[uint8](s[i])
@@ -53,24 +53,24 @@ const
   B64UrlAlphabet* = newAlphabet64("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdef" &
                                   "ghijklmnopqrstuvwxyz0123456789-_")
 
-proc encodedLength*(btype: typedesc[Base64Types],
+func encodedLength*(btype: typedesc[Base64Types],
                     length: int): int {.inline.} =
-  ## Return estimated length of BASE64 encoded value for plain length
+  ## Return estimated length of Base64 encoded value for plain length
   ## ``length``.
   result = (((length + 2) div 3) * 4) + 1
 
-proc decodedLength*(btype: typedesc[Base64Types],
+func decodedLength*(btype: typedesc[Base64Types],
                     length: int): int {.inline.} =
-  ## Return estimated length of decoded value of BASE64 encoded value of length
+  ## Return estimated length of decoded value of Base64 encoded value of length
   ## ``length``.
   when (btype is Base64Pad) or (btype is Base64UrlPad):
     result = ((length + 3 - 1) div 3) * 4
   elif (btype is Base64) or (btype is Base64Url):
     result = (length * 4 + 3 - 1) div 3
 
-proc encode*(btype: typedesc[Base64Types], inbytes: openArray[byte],
+func encode*(btype: typedesc[Base64Types], inbytes: openArray[byte],
              outstr: var openArray[char], outlen: var int): Base64Status =
-  ## Encode array of bytes ``inbytes`` using BASE64 encoding and store
+  ## Encode array of bytes ``inbytes`` using Base64 encoding and store
   ## result to ``outstr``.
   ##
   ## On success ``Base64Status.Success`` will be returned and ``outlen`` will
@@ -126,9 +126,9 @@ proc encode*(btype: typedesc[Base64Types], inbytes: openArray[byte],
     outlen = offset
     result = Base64Status.Success
 
-proc encode*(btype: typedesc[Base64Types],
+func encode*(btype: typedesc[Base64Types],
              inbytes: openArray[byte]): string {.inline.} =
-  ## Encode array of bytes ``inbytes`` using BASE64 encoding and return
+  ## Encode array of bytes ``inbytes`` using Base64 encoding and return
   ## encoded string.
   var size = btype.encodedLength(len(inbytes))
   result = newString(size)
@@ -138,15 +138,15 @@ proc encode*(btype: typedesc[Base64Types],
   else:
     result = ""
 
-proc decode*[T: byte|char](btype: typedesc[Base64Types], instr: openArray[T],
+func decode*[T: byte|char](btype: typedesc[Base64Types], instr: openArray[T],
              outbytes: var openArray[byte], outlen: var int): Base64Status =
-  ## Decode BASE64 string and store array of bytes to ``outbytes``. On success
+  ## Decode Base64 string and store array of bytes to ``outbytes``. On success
   ## ``Base64Status.Success`` will be returned and ``outlen`` will be set
   ## to number of bytes stored.
   ##
   ## Length of ``outbytes`` must be equal or more then ``len(instr) + 4``.
   ##
-  ## If ``instr`` has characters which are not part of BASE64 alphabet, then
+  ## If ``instr`` has characters which are not part of Base64 alphabet, then
   ## ``Base64Status.Incorrect`` will be returned and ``outlen`` will be set to
   ## ``0``.
   ##
@@ -223,9 +223,9 @@ proc decode*[T: byte|char](btype: typedesc[Base64Types], instr: openArray[T],
   outlen = k
   result = Base64Status.Success
 
-proc decode*[T: byte|char](btype: typedesc[Base64Types],
+func decode*[T: byte|char](btype: typedesc[Base64Types],
                            instr: openArray[T]): seq[byte] =
-  ## Decode BASE64 string ``instr`` and return sequence of bytes as result.
+  ## Decode Base64 string ``instr`` and return sequence of bytes as result.
   if len(instr) == 0:
     result = newSeq[byte]()
   else:

--- a/stew/sorted_set/rbtree_rotate.nim
+++ b/stew/sorted_set/rbtree_rotate.nim
@@ -1,5 +1,5 @@
 # Nimbus
-# Copyright (c) 2018-2023 Status Research & Development GmbH
+# Copyright (c) 2018-2025 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or
 #    http://www.apache.org/licenses/LICENSE-2.0)
@@ -13,7 +13,7 @@ import
 
 {.push raises: [].}
 
-proc rbTreeRotateSingle*[C](node: RbNodeRef[C]; dir: RbDir): RbNodeRef[C] =
+func rbTreeRotateSingle*[C](node: RbNodeRef[C]; dir: RbDir): RbNodeRef[C] =
   ## Perform a single red-black tree rotation in the specified direction.
   ## This function assumes that all nodes are valid for a rotation.
   ##
@@ -34,8 +34,7 @@ proc rbTreeRotateSingle*[C](node: RbNodeRef[C]; dir: RbDir): RbNodeRef[C] =
 
   save
 
-
-proc rbTreeRotateDouble*[C](node: RbNodeRef[C]; dir:  RbDir): RbNodeRef[C] =
+func rbTreeRotateDouble*[C](node: RbNodeRef[C]; dir:  RbDir): RbNodeRef[C] =
   ## Perform a double red-black rotation in the specified direction.
   ## This function assumes that all nodes are valid for a rotation.
   ##

--- a/tests/test_base10.nim
+++ b/tests/test_base10.nim
@@ -1,7 +1,7 @@
 import unittest2
 import ../stew/base10
 
-when defined(nimHasUsed): {.used.}
+{.used.}
 
 const
   DecVectors = [

--- a/tests/test_base32.nim
+++ b/tests/test_base32.nim
@@ -1,7 +1,7 @@
 import unittest2
 import ../stew/base32
 
-when defined(nimHasUsed): {.used.}
+{.used.}
 
 const TVBaseUpperPadding = [
   ["f", "MY======"],
@@ -406,4 +406,3 @@ suite "BASE32 encoding test suite":
       decsize == 0
       HexBase32Lower.decode("ww", decres, decsize) == Base32Status.Incorrect
       decsize == 0
-

--- a/tests/test_base58.nim
+++ b/tests/test_base58.nim
@@ -1,7 +1,7 @@
 import unittest2
 import ../stew/base58
 
-when defined(nimHasUsed): {.used.}
+{.used.}
 
 func hexToBytes*(a: string, result: var openArray[byte]) =
   doAssert(len(a) == 2 * len(result))
@@ -129,4 +129,3 @@ suite "BASE58 encoding test suite":
       decsize == 0
       Base58.decode("2O", decres, decsize) == Base58Status.Incorrect
       decsize == 0
-

--- a/tests/test_base64.nim
+++ b/tests/test_base64.nim
@@ -1,7 +1,7 @@
 import unittest2
 import ../stew/[base64, byteutils]
 
-when defined(nimHasUsed): {.used.}
+{.used.}
 
 const TVBasePadding = [
   ["f", "Zg=="],

--- a/tests/test_objects.nim
+++ b/tests/test_objects.nim
@@ -2,9 +2,7 @@ import
   unittest2, typetraits,
   ../stew/objects
 
-when defined(nimHasUsed):
-  {.used.}
-
+{.used.}
 {.experimental: "notnil".}
 
 template isZeroAndDefault(x: auto): bool =


### PR DESCRIPTION
- `nimHasUsed` is true for all versions of NIm supported by `nim-stew`, currently 1.6 and newer;
- prefer `func` to `proc`
- in `BASE32`/`BASE58`/`BASE64`, `BASE` isn't in those contexts an acronym and shouldn't be capitalized as such