### PR TITLE
bump version to nim-stew v0.4.0

### DIFF
--- a/stew.nimble
+++ b/stew.nimble
@@ -1,7 +1,7 @@
 mode = ScriptMode.Verbose
 
 packageName   = "stew"
-version       = "0.3.0"
+version       = "0.4.0"
 author        = "Status Research & Development GmbH"
 description   = "Backports, standard library candidates and small utilities that don't yet deserve their own repository"
 license       = "MIT or Apache License 2.0"


### PR DESCRIPTION
We need a new version to refer to in `nim-libp2p`'s `.nimble file (recommended as per [@arnetheduck's comment](https://discord.com/channels/613988663034118151/740631022080622745/1371484042800664671)) in order to import `base36` functionalities.