### PR TITLE
return `var openArray` from `makeOpenArray` in buggy nim versions

### DIFF
--- a/stew/ptrops.nim
+++ b/stew/ptrops.nim
@@ -57,7 +57,12 @@ func makeUncheckedArray*[T](p: ptr T): ptr UncheckedArray[T] =
   cast[ptr UncheckedArray[T]](p)
 
 template makeOpenArray*[T](p: ptr T, len: Natural): openArray[T] =
-  toOpenArray(cast[ptr UncheckedArray[T]](p), 0, len - 1)
+  # `var` works around https://github.com/nim-lang/Nim/issues/19171
+  var tmp = cast[ptr UncheckedArray[T]](p)
+  toOpenArray(tmp, 0, len - 1)
 
 template makeOpenArray*(p: pointer, T: type, len: Natural): openArray[T] =
-  toOpenArray(cast[ptr UncheckedArray[T]](p), 0, len - 1)
+  # `var` works around https://github.com/nim-lang/Nim/issues/19171
+  # fixed in 2.0.10
+  var tmp = cast[ptr UncheckedArray[T]](p)
+  toOpenArray(tmp, 0, len - 1)

--- a/tests/test_ptrops.nim
+++ b/tests/test_ptrops.nim
@@ -91,3 +91,9 @@ suite "ptrops":
       var v = [2, 3]
       check:
         makeUncheckedArray(baseAddr v)[1] == 3
+
+  test "var makeOpenArray":
+    # fixed in 2.0.10+: https://github.com/nim-lang/Nim/pull/23882
+    proc takesVar(v: var openArray[byte]) = discard
+    var tmp: byte
+    check compiles(takesVar(makeOpenArray(addr tmp, 1)))


### PR DESCRIPTION
Workaround from https://github.com/nim-lang/Nim/issues/19171