### PR TITLE
strings: one of these is sufficient

### DIFF
--- a/stew/shims/strings.nim
+++ b/stew/shims/strings.nim
@@ -1,3 +1,4 @@
-func add*(str: var string, chars: openArray[char]) =
-  for c in chars:
-    str.add c
+import stew/strings
+export strings
+
+{.deprecated: "stew/strings".}

--- a/stew/strings.nim
+++ b/stew/strings.nim
@@ -3,4 +3,3 @@ proc add*(s: var string, data: openArray[char]) =
     let prevEnd = s.len
     s.setLen(prevEnd + data.len)
     copyMem(addr s[prevEnd], unsafeAddr data[0], data.len)
-


### PR DESCRIPTION
there's no `strings` in `std` so the one in shims seems less canonical