### PR TITLE
rm deprecated shims/parseutils

### DIFF
--- a/stew/shims/parseutils.nim
+++ b/stew/shims/parseutils.nim
@@ -1,2 +1,0 @@
-import std/parseutils; export parseutils
-{.deprecated: "std/parseutils".}


### PR DESCRIPTION
Deprecated in:
- https://github.com/status-im/nim-stew/pull/257