### PR TITLE
enums: fix `hasHoles` overflow in 32bit platforms for int32 enum values 

### DIFF
--- a/stew/enums.nim
+++ b/stew/enums.nim
@@ -9,7 +9,7 @@
 
 {.push raises: [].}
 
-import std/[macros, options, sequtils]
+import std/[macros, options, sequtils, typetraits]
 
 type EnumStyle* {.pure.} = enum
   Numeric
@@ -85,14 +85,10 @@ template enumStrValuesSeq*(E: type[enum]): seq[string] =
   const values = @(enumStrValuesArray E)
   values
 
-macro enumLen(T: type[enum]): int =
-  let len = T.getType[1].len - 2
-  quote: `len`
-
 func hasHoles*(T: type enum): bool =
   # As an enum is always sorted, just substract the first and the last ordinal value
   # and compare the result to the number of element in it will do the trick.
-  const ret = int64(T.high.ord) - int64(T.low.ord) != int64(enumLen(T))
+  const ret = int64(T.high.ord) - int64(T.low.ord) != int64(enumLen(T) - 1)
   ret
 
 func contains*[I: SomeInteger](e: type[enum], v: I): bool =

--- a/stew/enums.nim
+++ b/stew/enums.nim
@@ -85,7 +85,7 @@ template enumStrValuesSeq*(E: type[enum]): seq[string] =
   const values = @(enumStrValuesArray E)
   values
 
-func hasHoles*(T: type enum): bool =
+template hasHoles*(T: type enum): bool =
   # As an enum is always sorted, just substract the first and the last ordinal value
   # and compare the result to the number of element in it will do the trick.
   const ret = int64(T.high.ord) - int64(T.low.ord) != int64(enumLen(T) - 1)

--- a/stew/enums.nim
+++ b/stew/enums.nim
@@ -83,16 +83,19 @@ template enumStrValuesSeq*(E: type[enum]): seq[string] =
   const values = @(enumStrValuesArray E)
   values
 
-macro hasHoles*(T: type[enum]): bool =
+macro enumLen(T: type[enum]): int =
+  let len = T.getType[1].len - 2
+  quote: `len`
+
+proc hasHoles*(T: type enum): bool =
   # As an enum is always sorted, just substract the first and the last ordinal value
   # and compare the result to the number of element in it will do the trick.
-  let len = T.getType[1].len - 2
-
-  quote: int64(`T`.high.ord) - int64(`T`.low.ord) != int64(`len`)
+  const ret = int64(T.high.ord) - int64(T.low.ord) != int64(enumLen(T))
+  ret
 
 func contains*[I: SomeInteger](e: type[enum], v: I): bool =
   when I is uint64:
-    if v > int.high.uint64:
+    if v > int64.high.uint64:
       return false
   when e.hasHoles():
     v.int64 in enumRangeInt64(e)

--- a/stew/enums.nim
+++ b/stew/enums.nim
@@ -88,7 +88,7 @@ template enumStrValuesSeq*(E: type[enum]): seq[string] =
 template hasHoles*(T: type enum): bool =
   # As an enum is always sorted, just substract the first and the last ordinal value
   # and compare the result to the number of element in it will do the trick.
-  const ret = int64(T.high.ord) - int64(T.low.ord) != int64(enumLen(T) - 1)
+  const ret = cast[uint64](T.high.ord) - cast[uint64](T.low.ord) != cast[uint64](enumLen(T) - 1)
   ret
 
 func contains*[I: SomeInteger](e: type[enum], v: I): bool =

--- a/stew/enums.nim
+++ b/stew/enums.nim
@@ -88,7 +88,7 @@ template enumStrValuesSeq*(E: type[enum]): seq[string] =
 template hasHoles*(T: type enum): bool =
   # As an enum is always sorted, just substract the first and the last ordinal value
   # and compare the result to the number of element in it will do the trick.
-  const ret = cast[uint64](T.high.ord) - cast[uint64](T.low.ord) != cast[uint64](enumLen(T) - 1)
+  const ret = int64(T.high.ord) - int64(T.low.ord) != int64(enumLen(T) - 1)
   ret
 
 func contains*[I: SomeInteger](e: type[enum], v: I): bool =

--- a/stew/enums.nim
+++ b/stew/enums.nim
@@ -88,7 +88,7 @@ macro hasHoles*(T: type[enum]): bool =
   # and compare the result to the number of element in it will do the trick.
   let len = T.getType[1].len - 2
 
-  quote: uint64(`T`.high.ord) - uint64(`T`.low.ord) != uint64(`len`)
+  quote: int64(`T`.high.ord) - int64(`T`.low.ord) != int64(`len`)
 
 func contains*[I: SomeInteger](e: type[enum], v: I): bool =
   when I is uint64:

--- a/stew/enums.nim
+++ b/stew/enums.nim
@@ -86,10 +86,7 @@ template enumStrValuesSeq*(E: type[enum]): seq[string] =
   values
 
 template hasHoles*(T: type enum): bool =
-  # As an enum is always sorted, just substract the first and the last ordinal value
-  # and compare the result to the number of element in it will do the trick.
-  const ret = int64(T.high.ord) - int64(T.low.ord) != int64(enumLen(T) - 1)
-  ret
+  T is typetraits.HoleyEnum
 
 func contains*[I: SomeInteger](e: type[enum], v: I): bool =
   when I is uint64:

--- a/stew/enums.nim
+++ b/stew/enums.nim
@@ -85,10 +85,11 @@ template enumStrValuesSeq*(E: type[enum]): seq[string] =
   const values = @(enumStrValuesArray E)
   values
 
-func hasHoles*(T: type enum): bool {.compileTime.} =
+func hasHoles*(T: type enum): bool =
   # As an enum is always sorted, just substract the first and the last ordinal value
   # and compare the result to the number of element in it will do the trick.
-  int64(T.high.ord) - int64(T.low.ord) != int64(enumLen(T) - 1)
+  const ret = int64(T.high.ord) - int64(T.low.ord) != int64(enumLen(T) - 1)
+  ret
 
 func contains*[I: SomeInteger](e: type[enum], v: I): bool =
   when I is uint64:

--- a/stew/enums.nim
+++ b/stew/enums.nim
@@ -85,11 +85,10 @@ template enumStrValuesSeq*(E: type[enum]): seq[string] =
   const values = @(enumStrValuesArray E)
   values
 
-func hasHoles*(T: type enum): bool =
+func hasHoles*(T: type enum): bool {.compileTime.} =
   # As an enum is always sorted, just substract the first and the last ordinal value
   # and compare the result to the number of element in it will do the trick.
-  const ret = int64(T.high.ord) - int64(T.low.ord) != int64(enumLen(T) - 1)
-  ret
+  int64(T.high.ord) - int64(T.low.ord) != int64(enumLen(T) - 1)
 
 func contains*[I: SomeInteger](e: type[enum], v: I): bool =
   when I is uint64:

--- a/stew/enums.nim
+++ b/stew/enums.nim
@@ -7,6 +7,8 @@
 #
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
+{.push raises: [].}
+
 import std/[macros, options, sequtils]
 
 type EnumStyle* {.pure.} = enum
@@ -87,7 +89,7 @@ macro enumLen(T: type[enum]): int =
   let len = T.getType[1].len - 2
   quote: `len`
 
-proc hasHoles*(T: type enum): bool =
+func hasHoles*(T: type enum): bool =
   # As an enum is always sorted, just substract the first and the last ordinal value
   # and compare the result to the number of element in it will do the trick.
   const ret = int64(T.high.ord) - int64(T.low.ord) != int64(enumLen(T))

--- a/stew/enums.nim
+++ b/stew/enums.nim
@@ -88,7 +88,7 @@ macro hasHoles*(T: type[enum]): bool =
   # and compare the result to the number of element in it will do the trick.
   let len = T.getType[1].len - 2
 
-  quote: `T`.high.ord - `T`.low.ord != `len`
+  quote: uint64(`T`.high.ord) - uint64(`T`.low.ord) != uint64(`len`)
 
 func contains*[I: SomeInteger](e: type[enum], v: I): bool =
   when I is uint64:

--- a/tests/test_enums.nim
+++ b/tests/test_enums.nim
@@ -160,12 +160,18 @@ suite "enums":
         B4 = 2000
         C4 = 4000
 
+      WithLimits = enum
+        A5 = int32.low()
+        B5 = 0
+        C5 = int32.high()
+
     check:
       hasHoles(EnumWithOneValue) == false
       hasHoles(WithoutHoles) == false
       hasHoles(WithoutHoles2) == false
       hasHoles(WithHoles) == true
       hasHoles(WithBigHoles) == true
+      hasHoles(WithLimits) == true
 
   test "checkedEnumAssign":
     type
@@ -184,10 +190,16 @@ suite "enums":
         B3 = 3
         C3
 
+      EnumWithLimits = enum
+        A4 = int32.low()
+        B4 = 0
+        C4 = int32.high()
+
     var
       e1 = A1
       e2 = A2
       e3 = A3
+      e4 = A4
 
     check:
       checkedEnumAssign(e1, 2)
@@ -216,3 +228,12 @@ suite "enums":
       e3 == A3
       not checkedEnumAssign(e3, -1)
       e3 == A3
+
+      checkedEnumAssign(e4, 0)
+      e4 == B4
+      not checkedEnumAssign(e4, 1)
+      e4 == B4
+      checkedEnumAssign(e4, int32.high)
+      e4 == C4
+      not checkedEnumAssign(e4, -1)
+      e4 == C4

--- a/tests/test_enums.nim
+++ b/tests/test_enums.nim
@@ -160,10 +160,15 @@ suite "enums":
         B4 = 2000
         C4 = 4000
 
-      WithLimits = enum
+      WithLimits32 = enum
         A5 = int32.low()
         B5 = 0
         C5 = int32.high()
+
+      WithLimits64 = enum
+        A6 = int64.low()
+        B6 = 0
+        C6 = int64.high()
 
     check:
       hasHoles(EnumWithOneValue) == false
@@ -171,7 +176,8 @@ suite "enums":
       hasHoles(WithoutHoles2) == false
       hasHoles(WithHoles) == true
       hasHoles(WithBigHoles) == true
-      hasHoles(WithLimits) == true
+      hasHoles(WithLimits32) == true
+      hasHoles(WithLimits64) == true
 
   test "checkedEnumAssign":
     type

--- a/tests/test_enums.nim
+++ b/tests/test_enums.nim
@@ -160,15 +160,10 @@ suite "enums":
         B4 = 2000
         C4 = 4000
 
-      WithLimits32 = enum
+      WithLimits = enum
         A5 = int32.low()
         B5 = 0
         C5 = int32.high()
-
-      WithLimits64 = enum
-        A6 = int64.low()
-        B6 = 0
-        C6 = int64.high()
 
     check:
       hasHoles(EnumWithOneValue) == false
@@ -176,8 +171,7 @@ suite "enums":
       hasHoles(WithoutHoles2) == false
       hasHoles(WithHoles) == true
       hasHoles(WithBigHoles) == true
-      hasHoles(WithLimits32) == true
-      hasHoles(WithLimits64) == true
+      hasHoles(WithLimits) == true
 
   test "checkedEnumAssign":
     type

--- a/tests/test_enums.nim
+++ b/tests/test_enums.nim
@@ -9,7 +9,7 @@
 
 {.used.}
 
-import std/typetraits, unittest2, ../stew/enums
+import unittest2, ../stew/enums
 
 suite "enumStyle":
   test "OrdinalEnum":

--- a/tests/test_enums.nim
+++ b/tests/test_enums.nim
@@ -165,11 +165,6 @@ suite "enums":
         B5 = 0
         C5 = int32.high()
 
-      WithLimits64 = enum
-        A6 = int64.low()
-        B6 = 0
-        C6 = int64.high()
-
     check:
       hasHoles(EnumWithOneValue) == false
       hasHoles(WithoutHoles) == false
@@ -177,7 +172,6 @@ suite "enums":
       hasHoles(WithHoles) == true
       hasHoles(WithBigHoles) == true
       hasHoles(WithLimits32) == true
-      hasHoles(WithLimits64) == true
 
   test "checkedEnumAssign":
     type


### PR DESCRIPTION
this fixes an overflow error in `hasHoles` when enum values hole is greater than int32.high. Still overflows for holes greater than int64.high.

makes `hasHoles` an alias for `T is typetraits.HoleyEnum`. 

the initial attempt works for int64 values in Nim 2 (fails in Nim 1.6 since cannot convert negative numbers to uint64) when changing int64 conversion to uint64, see https://github.com/status-im/nim-stew/pull/271/commits/363dd2de36f93e83d1cb59b7f649da5d7d4192ff