### PR TITLE
ptrops: add missing `makeUncheckedArray` overload

### DIFF
--- a/stew/ptrops.nim
+++ b/stew/ptrops.nim
@@ -56,6 +56,9 @@ func baseAddr*[T](x: openArray[T]): ptr T =
 func makeUncheckedArray*[T](p: ptr T): ptr UncheckedArray[T] =
   cast[ptr UncheckedArray[T]](p)
 
+func makeUncheckedArray*(p: pointer, T: type): ptr UncheckedArray[T] =
+  cast[ptr UncheckedArray[T]](p)
+
 template makeOpenArray*[T](p: ptr T, len: Natural): openArray[T] =
   # `var` works around https://github.com/nim-lang/Nim/issues/19171
   var tmp = cast[ptr UncheckedArray[T]](p)

--- a/tests/test_ptrops.nim
+++ b/tests/test_ptrops.nim
@@ -91,6 +91,7 @@ suite "ptrops":
       var v = [2, 3]
       check:
         makeUncheckedArray(baseAddr v)[1] == 3
+        makeUncheckedArray(cast[pointer](baseAddr v), int)[1] == 3
 
   test "var makeOpenArray":
     # fixed in 2.0.10+: https://github.com/nim-lang/Nim/pull/23882


### PR DESCRIPTION
Add overload for `pointer`, same as `makeOpenArray`