### PR TITLE
`toHex`: faster vectorized version

### DIFF
--- a/stew/byteutils.nim
+++ b/stew/byteutils.nim
@@ -212,21 +212,38 @@ iterator to0xHex*(ba: openArray[byte]): char =
   for b in toHex(ba):
     yield b
 
+{.push checks: off.}
+# https://lemire.me/blog/2026/02/02/converting-data-to-hexadecimal-outputs-quickly/
+# https://github.com/nodejs/nbytes/pull/12
+func toHex(dst: var openArray[char], ba: openArray[byte]) =
+  ## Faster vectorized toHex version
+  template nibble(x: uint8): untyped =
+    # char(x + uint8('0') + (uint8(x > 9'u8) * 39'u8))
+    char(x + (if x >= 10: uint8('a') - 10 else: uint8('0')))
+
+  doAssert dst.len >= ba.len * 2
+  var i = 0
+  for c in ba:
+    dst[i+0] = nibble(c shr 4 and 0x0f'u8)
+    dst[i+1] = nibble(c and 0x0f'u8)
+    i += 2
+{.pop.}
+
 func toHex*(ba: openArray[byte]): string {.inline.} =
   ## Convert a byte-array to its hex representation
   ## Output is in lowercase
   ## No "endianness" reordering is done.
-  result = newStringOfCap(2 * ba.len)
-  for c in toHex(ba):
-    result.add c
+  result = newString(2 * ba.len)
+  toHex(result, ba)
 
 func to0xHex*(ba: openArray[byte]): string {.inline.} =
   ## Convert a byte-array to its hex representation
   ## Output is in lowercase
   ## No "endianness" reordering is done.
-  result = newStringOfCap(2 * ba.len + 2)
-  for c in to0xHex(ba):
-    result.add c
+  result = newString(2 * ba.len + 2)
+  result[0] = '0'
+  result[1] = 'x'
+  toHex(toOpenArray(result, 2, result.high), ba)
 
 func toBytes*(s: openArray[char]): seq[byte] =
   ## Convert a char array to the corresponding byte sequence - since strings in

--- a/tests/test_byteutils.nim
+++ b/tests/test_byteutils.nim
@@ -15,6 +15,14 @@ proc compilationTest {.exportc: "compilationTest".} =
   var bytes = @[1.byte, 2, 3, 4]
   writeFile("test", bytes)
 
+func iterHex(ba: openArray[byte]): string =
+  for c in toHex(ba):
+    result.add c
+
+func iter0xHex(ba: openArray[byte]): string =
+  for c in to0xHex(ba):
+    result.add c
+
 suite "Byte utils":
   const simpleBArray = [0x12.byte, 0x34, 0x56, 0x78]
 
@@ -105,14 +113,43 @@ suite "Byte utils":
     expect(ValueError): echo array[5, byte].fromHex(s)
 
   dualTest "toHex":
+    check toHex(default(seq[byte])) == ""
     check simpleBArray.toHex == "12345678"
+    check simpleBArray.iterHex == "12345678"
     check hexToSeqByte("12345678") == simpleBArray
     check hexToSeqByte("00") == [byte 0]
     check hexToSeqByte("0x") == []
     expect(ValueError): discard hexToSeqByte("1234567")
     expect(ValueError): discard hexToSeqByte("X")
     expect(ValueError): discard hexToSeqByte("0")
+    check to0xHex(default(seq[byte])) == "0x"
     check simpleBArray.to0xHex == "0x12345678"
+    check simpleBArray.iter0xHex == "0x12345678"
+
+  dualTest "toHex: every byte value":
+    var bytes = newSeq[byte](256)
+    for i in 0 ..< 256:
+      bytes[i] = byte(i)
+
+    const expected =
+      "000102030405060708090a0b0c0d0e0f101112131415161718" &
+      "191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f3031" &
+      "32333435363738393a3b3c3d3e3f404142434445464748494a" &
+      "4b4c4d4e4f505152535455565758595a5b5c5d5e5f60616263" &
+      "6465666768696a6b6c6d6e6f707172737475767778797a7b7c" &
+      "7d7e7f808182838485868788898a8b8c8d8e8f909192939495" &
+      "969798999a9b9c9d9e9fa0a1a2a3a4a5a6a7a8a9aaabacadae" &
+      "afb0b1b2b3b4b5b6b7b8b9babbbcbdbebfc0c1c2c3c4c5c6c7" &
+      "c8c9cacbcccdcecfd0d1d2d3d4d5d6d7d8d9dadbdcdddedfe0" &
+      "e1e2e3e4e5e6e7e8e9eaebecedeeeff0f1f2f3f4f5f6f7f8f9fafbfcfdfeff"
+
+    check:
+      bytes.toHex == expected
+      bytes.to0xHex == "0x" & expected
+      iterHex(bytes) == expected
+      iter0xHex(bytes) == "0x" & expected
+      hexToSeqByte(bytes.toHex) == bytes
+      hexToSeqByte(bytes.to0xHex) == bytes
 
   test "Array concatenation":
     check simpleBArray & simpleBArray ==

--- a/tests/test_byteutils.nim
+++ b/tests/test_byteutils.nim
@@ -151,6 +151,7 @@ suite "Byte utils":
       hexToSeqByte(bytes.toHex) == bytes
       hexToSeqByte(bytes.to0xHex) == bytes
 
+
   test "Array concatenation":
     check simpleBArray & simpleBArray ==
       [0x12.byte, 0x34, 0x56, 0x78, 0x12, 0x34, 0x56, 0x78]

--- a/tests/test_byteutils.nim
+++ b/tests/test_byteutils.nim
@@ -151,7 +151,6 @@ suite "Byte utils":
       hexToSeqByte(bytes.toHex) == bytes
       hexToSeqByte(bytes.to0xHex) == bytes
 
-
   test "Array concatenation":
     check simpleBArray & simpleBArray ==
       [0x12.byte, 0x34, 0x56, 0x78, 0x12, 0x34, 0x56, 0x78]


### PR DESCRIPTION
Implementation from https://lemire.me/blog/2026/02/02/converting-data-to-hexadecimal-outputs-quickly/

The iterator version is not changed as its usage is unlikely to get vectorized.

HEAD:

```
input: 10                  0.07 GB/s   (3690367 reps)
input: 100                 0.11 GB/s   (574181 reps)
input: 1000                0.12 GB/s   (60399 reps)
input: 10000               0.12 GB/s   (6069 reps)
```

This PR:

```
input: 10                  0.14 GB/s   (7101521 reps)
input: 100                 1.23 GB/s   (6156846 reps)
input: 1000                4.19 GB/s   (2096510 reps)
input: 10000               5.02 GB/s   (250810 reps)
```

Note the smaller inputs are dominated by `newString`.